### PR TITLE
Default to prepare_v2 if prepare_v3 not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: dart
+sudo: required
+dart:
+  - stable
+  - beta
+  - dev
+before_script:
+  - sudo apt-get -y install libsqlite3-dev
+script:
+  - cd sqlite3
+  - pub get
+  - pub run test

--- a/sqlite3/lib/src/ffi/sqlite3.ffi.dart
+++ b/sqlite3/lib/src/ffi/sqlite3.ffi.dart
@@ -13,6 +13,8 @@ class sqlite3_value extends Struct {}
 
 class sqlite3_context extends Struct {}
 
+// ignore_for_file: avoid_private_typedef_functions
+
 typedef _sqlite3_open_v2_native = Int32 Function(
     Pointer<char>, Pointer<Pointer<sqlite3>>, Int32, Pointer<char>);
 typedef sqlite3_open_v2_dart = int Function(Pointer<char> filename,
@@ -61,6 +63,18 @@ typedef sqlite3_prepare_v3_dart = int Function(
     Pointer<Void> zSql,
     int nByte,
     int prepFlags,
+    Pointer<Pointer<sqlite3_stmt>> ppStmt,
+    Pointer<Pointer<char>> pzTail);
+typedef _sqlite3_prepare_v2_native = Int32 Function(
+    Pointer<sqlite3>,
+    Pointer<Void>,
+    Int32,
+    Pointer<Pointer<sqlite3_stmt>>,
+    Pointer<Pointer<char>>);
+typedef sqlite3_prepare_v2_dart = int Function(
+    Pointer<sqlite3> db,
+    Pointer<Void> zSql,
+    int nByte,
     Pointer<Pointer<sqlite3_stmt>> ppStmt,
     Pointer<Pointer<char>> pzTail);
 typedef _sqlite3_finalize_native = Int32 Function(Pointer<sqlite3_stmt>);
@@ -206,6 +220,7 @@ class Bindings {
   final sqlite3_changes_dart sqlite3_changes;
   final sqlite3_exec_dart sqlite3_exec;
   final sqlite3_prepare_v3_dart sqlite3_prepare_v3;
+  final sqlite3_prepare_v2_dart sqlite3_prepare_v2;
   final sqlite3_finalize_dart sqlite3_finalize;
   final sqlite3_step_dart sqlite3_step;
   final sqlite3_reset_dart sqlite3_reset;
@@ -276,6 +291,8 @@ class Bindings {
                 'sqlite3_exec'),
         sqlite3_prepare_v3 = library.lookupFunction<_sqlite3_prepare_v3_native,
             sqlite3_prepare_v3_dart>('sqlite3_prepare_v3'),
+        sqlite3_prepare_v2 = library.lookupFunction<_sqlite3_prepare_v2_native,
+            sqlite3_prepare_v2_dart>('sqlite3_prepare_v2'),
         sqlite3_finalize = library.lookupFunction<_sqlite3_finalize_native,
             sqlite3_finalize_dart>('sqlite3_finalize'),
         sqlite3_step =

--- a/sqlite3/lib/src/ffi/sqlite3.ffi.dart
+++ b/sqlite3/lib/src/ffi/sqlite3.ffi.dart
@@ -205,6 +205,15 @@ typedef _sqlite3_result_text_native = Void Function(
 typedef sqlite3_result_text_dart = void Function(Pointer<sqlite3_context> ctx,
     Pointer<char> data, int length, Pointer<Void> destructor);
 
+// Handle old version of sqlite3
+sqlite3_prepare_v3_dart _lookupSqlite3PrepareV3OrNull(DynamicLibrary library) {
+  try {
+    return library.lookupFunction<_sqlite3_prepare_v3_native,
+        sqlite3_prepare_v3_dart>('sqlite3_prepare_v3');
+  } catch (_) {}
+  return null;
+}
+
 class Bindings {
   final sqlite3_open_v2_dart sqlite3_open_v2;
   final sqlite3_close_v2_dart sqlite3_close_v2;
@@ -289,8 +298,7 @@ class Bindings {
         sqlite3_exec =
             library.lookupFunction<_sqlite3_exec_native, sqlite3_exec_dart>(
                 'sqlite3_exec'),
-        sqlite3_prepare_v3 = library.lookupFunction<_sqlite3_prepare_v3_native,
-            sqlite3_prepare_v3_dart>('sqlite3_prepare_v3'),
+        sqlite3_prepare_v3 = _lookupSqlite3PrepareV3OrNull(library),
         sqlite3_prepare_v2 = library.lookupFunction<_sqlite3_prepare_v2_native,
             sqlite3_prepare_v2_dart>('sqlite3_prepare_v2'),
         sqlite3_finalize = library.lookupFunction<_sqlite3_finalize_native,

--- a/sqlite3/lib/src/impl/database.dart
+++ b/sqlite3/lib/src/impl/database.dart
@@ -121,7 +121,7 @@ class DatabaseImpl implements Database {
     }
 
     int resultCode;
-    try {
+    if (_bindings.sqlite3_prepare_v3 != null) {
       resultCode = _bindings.sqlite3_prepare_v3(
         _handle,
         sqlPtr.cast(),
@@ -130,7 +130,7 @@ class DatabaseImpl implements Database {
         stmtOut,
         nullPtr(),
       );
-    } catch (_) {
+    } else {
       // Handle old version of sqlite (needed on Ubuntu 16.04)
       resultCode = _bindings.sqlite3_prepare_v2(
         _handle,

--- a/sqlite3/lib/src/impl/database.dart
+++ b/sqlite3/lib/src/impl/database.dart
@@ -120,14 +120,26 @@ class DatabaseImpl implements Database {
       prepFlags |= SQLITE_PREPARE_NO_VTAB;
     }
 
-    final resultCode = _bindings.sqlite3_prepare_v3(
-      _handle,
-      sqlPtr.cast(),
-      bytes.length,
-      prepFlags,
-      stmtOut,
-      nullPtr(),
-    );
+    int resultCode;
+    try {
+      resultCode = _bindings.sqlite3_prepare_v3(
+        _handle,
+        sqlPtr.cast(),
+        bytes.length,
+        prepFlags,
+        stmtOut,
+        nullPtr(),
+      );
+    } catch (_) {
+      // Handle old version of sqlite (needed on Ubuntu 16.04)
+      resultCode = _bindings.sqlite3_prepare_v2(
+        _handle,
+        sqlPtr.cast(),
+        bytes.length,
+        stmtOut,
+        nullPtr(),
+      );
+    }
 
     final stmtPtr = stmtOut.value;
     stmtOut.free();


### PR DESCRIPTION
So it seems that travis is still stuck on Ubuntu 16.04 causing the library to fail (hence all the sqflite tests - I added an issue here https://travis-ci.community/t/change-ubuntu-distribution-from-16-04/9320 but I'm not sure when/if it will get fixed).

Here I propose to try to load prepare_v3 and load prepare_v2 if not found.

I also added travis tests (see the build history https://travis-ci.org/github/tekartikdev/sqlite3.dart/builds to see that it was failing before - I made 2 attemps to fix the issue). You might want to change the implementation.

Thanks!