### PR TITLE
applyWorkaround and openCipherOnAndroid

### DIFF
--- a/sqlcipher_flutter_libs/README.md
+++ b/sqlcipher_flutter_libs/README.md
@@ -23,6 +23,6 @@ There appears to be a problem when loading native libraries on Android 6 (see [t
 If you're seeing those crashes, you could try setting `android.bundle.enableUncompressedNativeLibs=false` in your `gradle.properties`
 file. Be aware that this increases the size of your application when installed.
 
-Alternatively, you can use the `applyWorkaroundToOpenSqlite3OnOldAndroidVersions` method from this library.
+Alternatively, you can use the `applyWorkaroundToOpenSqlCipherOnOldAndroidVersions` method from this library.
 It will try to open `sqlcipher` in Java, which seems to work more reliably. After the native library has been loaded from Java,
 we can open it in Dart too.

--- a/sqlcipher_flutter_libs/README.md
+++ b/sqlcipher_flutter_libs/README.md
@@ -10,7 +10,7 @@ If you're seeing those crashes, you could try setting `android.bundle.enableUnco
 file. Be aware that this increases the size of your application when installed.
 
 Alternatively, you can use the `applyWorkaroundToOpenSqlite3OnOldAndroidVersions` method from this library.
-It will try to open `sqlite3` in Java, which seems to work more reliably. After sqlite3 has been loaded from Java,
+It will try to open `sqlcipher` in Java, which seems to work more reliably. After the native library has been loaded from Java,
 we can open it in Dart too.
 
 ### working with Android

--- a/sqlcipher_flutter_libs/README.md
+++ b/sqlcipher_flutter_libs/README.md
@@ -3,16 +3,6 @@
 Flutter apps depending on this package will
 contain native `SQLCipher` libraries.
 
-### Problems on Android 6
-
-There appears to be a problem when loading native libraries on Android 6 (see [this issue](https://github.com/simolus3/moor/issues/895#issuecomment-720195005)).
-If you're seeing those crashes, you could try setting `android.bundle.enableUncompressedNativeLibs=false` in your `gradle.properties`
-file. Be aware that this increases the size of your application when installed.
-
-Alternatively, you can use the `applyWorkaroundToOpenSqlite3OnOldAndroidVersions` method from this library.
-It will try to open `sqlcipher` in Java, which seems to work more reliably. After the native library has been loaded from Java,
-we can open it in Dart too.
-
 ### working with Android
   on android you need to override the open method like this
 
@@ -25,3 +15,14 @@ __No changes are necessary for iOS__
 
 For more details on how to actually use this package in a Flutter app, see 
 [sqlite3](https://pub.dev/packages/sqlite3).
+
+
+### Problems on Android 6
+
+There appears to be a problem when loading native libraries on Android 6 (see [this issue](https://github.com/simolus3/moor/issues/895#issuecomment-720195005)).
+If you're seeing those crashes, you could try setting `android.bundle.enableUncompressedNativeLibs=false` in your `gradle.properties`
+file. Be aware that this increases the size of your application when installed.
+
+Alternatively, you can use the `applyWorkaroundToOpenSqlite3OnOldAndroidVersions` method from this library.
+It will try to open `sqlcipher` in Java, which seems to work more reliably. After the native library has been loaded from Java,
+we can open it in Dart too.

--- a/sqlcipher_flutter_libs/README.md
+++ b/sqlcipher_flutter_libs/README.md
@@ -21,7 +21,7 @@ we can open it in Dart too.
       OperatingSystem.android, openCipherOnAndroid);
 ```
 
-### no change needed for ios
+__No changes are necessary for iOS__
 
 For more details on how to actually use this package in a Flutter app, see 
 [sqlite3](https://pub.dev/packages/sqlite3).

--- a/sqlcipher_flutter_libs/README.md
+++ b/sqlcipher_flutter_libs/README.md
@@ -1,7 +1,27 @@
 # sqlcipher_flutter_libs
 
-This package intentionally contains no Dart code. Flutter apps depending on this package will
+Flutter apps depending on this package will
 contain native `SQLCipher` libraries.
+
+### Problems on Android 6
+
+There appears to be a problem when loading native libraries on Android 6 (see [this issue](https://github.com/simolus3/moor/issues/895#issuecomment-720195005)).
+If you're seeing those crashes, you could try setting `android.bundle.enableUncompressedNativeLibs=false` in your `gradle.properties`
+file. Be aware that this increases the size of your application when installed.
+
+Alternatively, you can use the `applyWorkaroundToOpenSqlite3OnOldAndroidVersions` method from this library.
+It will try to open `sqlite3` in Java, which seems to work more reliably. After sqlite3 has been loaded from Java,
+we can open it in Dart too.
+
+### working with Android
+  on android you need to override the open method like this
+
+```dart
+  open.overrideFor(
+      OperatingSystem.android, openCipherOnAndroid);
+```
+
+### no change needed for ios
 
 For more details on how to actually use this package in a Flutter app, see 
 [sqlite3](https://pub.dev/packages/sqlite3).

--- a/sqlcipher_flutter_libs/android/src/main/java/eu/simonbinder/sqlite3_flutter_libs/Sqlite3FlutterLibsPlugin.java
+++ b/sqlcipher_flutter_libs/android/src/main/java/eu/simonbinder/sqlite3_flutter_libs/Sqlite3FlutterLibsPlugin.java
@@ -1,18 +1,44 @@
 package eu.simonbinder.sqlite3_flutter_libs;
 
+import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
 
 /** Sqlite3FlutterLibsPlugin */
 public class Sqlite3FlutterLibsPlugin implements FlutterPlugin {
 
+  private static final String CHANNEL = "sqlcipher_flutter_libs";
+
+  private MethodChannel channel;
+
   @Override
-  public void onAttachedToEngine(FlutterPluginBinding binding) {
-    // Do nothing, we only need the native libraries.
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+    // Ideally, we shouldn't have to do anything, as the only purpose of this plugin is to provide
+    // sqlite native libraries to DynamicLibrary.open() in Dart. However, the loader of Android
+    // 6.0.1 is so broken that we can only dlopen stuff after loading it through System.openLibrary.
+    // So, we provide a platform method for that.
+    channel = new MethodChannel(binding.getBinaryMessenger(), CHANNEL);
+
+    channel.setMethodCallHandler(new MethodChannel.MethodCallHandler() {
+      @Override
+      public void onMethodCall(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+        try {
+          System.loadLibrary("sqlcipher");
+          result.success(null);
+        } catch (Throwable e) {
+          result.error(e.toString(), null, null);
+        }
+      }
+    });
   }
 
   @Override
-  public void onDetachedFromEngine(FlutterPluginBinding binding) {
-    // Again, nothing to do here.
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    if (channel != null) {
+      channel.setMethodCallHandler(null);
+      channel = null;
+    }
   }
 
 }

--- a/sqlcipher_flutter_libs/lib/sqlcipher_flutter_libs.dart
+++ b/sqlcipher_flutter_libs/lib/sqlcipher_flutter_libs.dart
@@ -13,7 +13,7 @@ import 'package:flutter/services.dart';
 
 const _platform = MethodChannel('sqlcipher_flutter_libs');
 
-/// Workaround to open sqlite3 on old Android versions.
+/// Workaround to open sqlcipher on old Android versions.
 ///
 /// On old Android versions, this method can help if you're having issues
 /// opening sqlite3 (e.g. if you're seeing crashes about `libsqlcipher.so` not

--- a/sqlcipher_flutter_libs/lib/sqlcipher_flutter_libs.dart
+++ b/sqlcipher_flutter_libs/lib/sqlcipher_flutter_libs.dart
@@ -22,7 +22,7 @@ const _platform = MethodChannel('sqlcipher_flutter_libs');
 ///
 /// Big thanks to [@knaeckeKami](https://github.com/knaeckeKami) for finding
 /// this workaround!!
-Future<void> applyWorkaroundToOpenSqlite3OnOldAndroidVersions() async {
+Future<void> applyWorkaroundToOpenSqlCipherOnOldAndroidVersions() async {
   if (!Platform.isAndroid) return;
 
   try {

--- a/sqlcipher_flutter_libs/lib/sqlcipher_flutter_libs.dart
+++ b/sqlcipher_flutter_libs/lib/sqlcipher_flutter_libs.dart
@@ -1,0 +1,56 @@
+/// This library contains a workaround neccessary to open dynamic libraries on
+/// old Android versions (6.0.1).
+///
+/// The purpose of the `sqlcipher_flutter_libs` package is to provide `sqlite3`
+/// native libraries when building Flutter apps for Android and iOS.
+library sqlcipher_flutter_libs;
+
+import 'dart:ffi';
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/services.dart';
+
+const _platform = MethodChannel('sqlcipher_flutter_libs');
+
+/// Workaround to open sqlite3 on old Android versions.
+///
+/// On old Android versions, this method can help if you're having issues
+/// opening sqlite3 (e.g. if you're seeing crashes about `libsqlcipher.so` not
+/// being available). To be safe, call this method before using apis from
+/// `package:sqlite3` or `package:moor/ffi.dart`.
+///
+/// Big thanks to [@knaeckeKami](https://github.com/knaeckeKami) for finding
+/// this workaround!!
+Future<void> applyWorkaroundToOpenSqlite3OnOldAndroidVersions() async {
+  if (!Platform.isAndroid) return;
+
+  try {
+    DynamicLibrary.open('libsqlcipher.so');
+  } on ArgumentError {
+    // Ok, the regular approach failed. Try to open sqlite3 in Java, which seems
+    // to fix the problem.
+    await _platform.invokeMethod('doesnt_matter');
+
+    // Try again. If it still fails we're out of luck.
+    DynamicLibrary.open('libsqlcipher.so');
+  }
+}
+
+DynamicLibrary openCipherOnAndroid() {
+  try {
+    return DynamicLibrary.open('libsqlcipher.so');
+  } catch (_) {
+    // On some (especially old) Android devices, we somehow can't dlopen
+    // libraries shipped with the apk. We need to find the full path of the
+    // library (/data/data/<id>/lib/libsqlcipher.so) and open that one.
+    // For details, see https://github.com/simolus3/moor/issues/420
+    final appIdAsBytes = File('/proc/self/cmdline').readAsBytesSync();
+
+    // app id ends with the first \0 character in here.
+    final endOfAppId = max(appIdAsBytes.indexOf(0), 0);
+    final appId = String.fromCharCodes(appIdAsBytes.sublist(0, endOfAppId));
+
+    return DynamicLibrary.open('/data/data/$appId/lib/libsqlcipher.so');
+  }
+}


### PR DESCRIPTION
fixed #29 

add applyWorkaroundToOpenSqlite3OnOldAndroidVersions

add openCipherOnAndroid function 

update readme 