### PR TITLE
Extract the column's table name in select results

### DIFF
--- a/sqlite3/lib/src/api/result_set.dart
+++ b/sqlite3/lib/src/api/result_set.dart
@@ -10,11 +10,13 @@ abstract class Cursor {
   /// The column names of this query, as returned by `sqlite3`.
   final List<String> columnNames;
 
-  /// The table names of this query, as returned by `sqlite3` or empty string when null.
-  ///
-  /// Empty string when the column is not directly associated
+  /// The table names of this query, as returned by `sqlite3`.
+  /// 
+  /// A table name is null when the column is not directly associated
   /// with a table, such as a computed column.
-  final List<String> tableNames;
+  /// The list is null when the sqlite library wasn't compiled with the SQLITE_ENABLE_COLUMN_METADATA 
+  /// C-preprocessor symbol.
+  final List<String?>? tableNames;
   // a result set can have multiple columns with the same name, but that's rare
   // and users usually use a name as index. So we cache that for O(1) lookups
   final Map<String, int> _calculatedIndexes;
@@ -29,7 +31,7 @@ abstract class Cursor {
 /// A [Cursor] that can only be read once, obtaining rows from the database as
 /// necessary.
 abstract class IteratingCursor extends Cursor implements Iterator<Row> {
-  IteratingCursor(List<String> columnNames, List<String> tableNames)
+  IteratingCursor(List<String> columnNames, List<String?>? tableNames)
       : super(columnNames, tableNames);
 }
 
@@ -40,7 +42,7 @@ class ResultSet extends Cursor
   /// The raw row data.
   final List<List<Object?>> rows;
 
-  ResultSet(List<String> columnNames, List<String> tableNames, this.rows)
+  ResultSet(List<String> columnNames, List<String?>? tableNames, this.rows)
       : super(columnNames, tableNames);
 
   @override
@@ -80,11 +82,20 @@ class Row
   Iterable<String> get keys => _result.columnNames;
 
   /// Returns a two-level map that on the first level contains the resolved
-  /// table name, and on the second level the column name (or its alias).
-  Map<String, Map<String, dynamic>> toTableColumnMap() {
-    final Map<String, Map<String, dynamic>> map = {};
+  /// non-aliased table name, and on the second level the column name (or its alias).
+  /// 
+  /// A table name (first level map key) is null when the column is not directly associated
+  /// with a table, such as a computed column.
+  /// The map is not null if the sqlite3 library was compiled with the SQLITE_ENABLE_COLUMN_METADATA 
+  /// C-preprocessor symbol. 
+  /// More information in https://www.sqlite.org/c3ref/column_database_name.html.
+  Map<String?, Map<String, dynamic>>? toTableColumnMap() {
+    if (_result.tableNames == null) {
+      return null;
+    }
+    final Map<String?, Map<String, dynamic>> map = {};
     for (int i = 0; i < _data.length; i++) {
-      final tableName = _result.tableNames[i];
+      final tableName = _result.tableNames![i];
       final columnName = _result.columnNames[i];
       final value = _data[i];
 

--- a/sqlite3/lib/src/api/result_set.dart
+++ b/sqlite3/lib/src/api/result_set.dart
@@ -11,11 +11,12 @@ abstract class Cursor {
   final List<String> columnNames;
 
   /// The table names of this query, as returned by `sqlite3`.
-  /// 
+  ///
   /// A table name is null when the column is not directly associated
   /// with a table, such as a computed column.
-  /// The list is null when the sqlite library wasn't compiled with the SQLITE_ENABLE_COLUMN_METADATA 
+  /// The list is null if the sqlite library was not compiled with the SQLITE_ENABLE_COLUMN_METADATA
   /// C-preprocessor symbol.
+  /// More information in https://www.sqlite.org/c3ref/column_database_name.html.
   final List<String?>? tableNames;
   // a result set can have multiple columns with the same name, but that's rare
   // and users usually use a name as index. So we cache that for O(1) lookups
@@ -83,11 +84,11 @@ class Row
 
   /// Returns a two-level map that on the first level contains the resolved
   /// non-aliased table name, and on the second level the column name (or its alias).
-  /// 
+  ///
   /// A table name (first level map key) is null when the column is not directly associated
   /// with a table, such as a computed column.
-  /// The map is not null if the sqlite3 library was compiled with the SQLITE_ENABLE_COLUMN_METADATA 
-  /// C-preprocessor symbol. 
+  /// The map is null if the sqlite3 library was not compiled with the SQLITE_ENABLE_COLUMN_METADATA
+  /// C-preprocessor symbol.
   /// More information in https://www.sqlite.org/c3ref/column_database_name.html.
   Map<String?, Map<String, dynamic>>? toTableColumnMap() {
     if (_result.tableNames == null) {

--- a/sqlite3/lib/src/ffi/ffi.dart
+++ b/sqlite3/lib/src/ffi/ffi.dart
@@ -29,15 +29,6 @@ extension Utf8Utils on Pointer<char> {
     return utf8
         .decode(cast<Uint8>().asTypedList(resolvedLength).buffer.asUint8List());
   }
-
-  String? readNullableString([int? length]) {
-    final pointer = cast<Uint8>();
-    if (pointer.isNullPointer) {
-      return null;
-    }
-
-    return readString(length);
-  }
 }
 
 extension PointerUtils on Pointer<NativeType> {

--- a/sqlite3/lib/src/ffi/ffi.dart
+++ b/sqlite3/lib/src/ffi/ffi.dart
@@ -29,6 +29,15 @@ extension Utf8Utils on Pointer<char> {
     return utf8
         .decode(cast<Uint8>().asTypedList(resolvedLength).buffer.asUint8List());
   }
+
+  String? readNullableString([int? length]) {
+    final pointer = cast<Uint8>();
+    if (pointer.isNullPointer) {
+      return null;
+    }
+
+    return readString(length);
+  }
 }
 
 extension PointerUtils on Pointer<NativeType> {

--- a/sqlite3/lib/src/ffi/sqlite3.ffi.dart
+++ b/sqlite3/lib/src/ffi/sqlite3.ffi.dart
@@ -202,7 +202,7 @@ class Bindings {
   final sqlite3_column_count_dart sqlite3_column_count;
   final sqlite3_bind_parameter_count_dart sqlite3_bind_parameter_count;
   final sqlite3_column_name_dart sqlite3_column_name;
-  final sqlite3_column_table_name_dart sqlite3_column_table_name;
+  final sqlite3_column_table_name_dart? sqlite3_column_table_name;
   final sqlite3_bind_blob64_dart sqlite3_bind_blob64;
   final sqlite3_bind_double_dart sqlite3_bind_double;
   final sqlite3_bind_int64_dart sqlite3_bind_int64;
@@ -282,9 +282,13 @@ class Bindings {
         sqlite3_column_name = library.lookupFunction<
             _sqlite3_column_name_native,
             sqlite3_column_name_dart>('sqlite3_column_name'),
-        sqlite3_column_table_name = library.lookupFunction<
-            _sqlite3_column_table_name_native,
-            sqlite3_column_table_name_dart>('sqlite3_column_table_name'),
+        sqlite3_column_table_name =
+            // Available if the library was compiled with the
+            // SQLITE_ENABLE_COLUMN_METADATA C-preprocessor symbol
+            library.providesSymbol('sqlite3_column_table_name')
+                ? library.lookupFunction<_sqlite3_column_table_name_native,
+                    sqlite3_column_table_name_dart>('sqlite3_column_table_name')
+                : null,
         sqlite3_bind_blob64 = library.lookupFunction<
             _sqlite3_bind_blob64_native,
             sqlite3_bind_blob64_dart>('sqlite3_bind_blob64'),

--- a/sqlite3/lib/src/ffi/sqlite3.ffi.dart
+++ b/sqlite3/lib/src/ffi/sqlite3.ffi.dart
@@ -65,6 +65,10 @@ typedef _sqlite3_column_name_native = Pointer<char> Function(
     Pointer<sqlite3_stmt>, Int32);
 typedef sqlite3_column_name_dart = Pointer<char> Function(
     Pointer<sqlite3_stmt> pStmt, int N);
+typedef _sqlite3_column_table_name_native = Pointer<char> Function(
+    Pointer<sqlite3_stmt>, Int32);
+typedef sqlite3_column_table_name_dart = Pointer<char> Function(
+    Pointer<sqlite3_stmt> pStmt, int N);
 typedef _sqlite3_bind_blob64_native = Int32 Function(
     Pointer<sqlite3_stmt>, Int32, Pointer<Void>, Uint64, Pointer<Void>);
 typedef sqlite3_bind_blob64_dart = int Function(Pointer<sqlite3_stmt> pStmt,
@@ -198,6 +202,7 @@ class Bindings {
   final sqlite3_column_count_dart sqlite3_column_count;
   final sqlite3_bind_parameter_count_dart sqlite3_bind_parameter_count;
   final sqlite3_column_name_dart sqlite3_column_name;
+  final sqlite3_column_table_name_dart sqlite3_column_table_name;
   final sqlite3_bind_blob64_dart sqlite3_bind_blob64;
   final sqlite3_bind_double_dart sqlite3_bind_double;
   final sqlite3_bind_int64_dart sqlite3_bind_int64;
@@ -277,6 +282,9 @@ class Bindings {
         sqlite3_column_name = library.lookupFunction<
             _sqlite3_column_name_native,
             sqlite3_column_name_dart>('sqlite3_column_name'),
+        sqlite3_column_table_name = library.lookupFunction<
+            _sqlite3_column_table_name_native,
+            sqlite3_column_table_name_dart>('sqlite3_column_table_name'),
         sqlite3_bind_blob64 = library.lookupFunction<
             _sqlite3_bind_blob64_native,
             sqlite3_bind_blob64_dart>('sqlite3_bind_blob64'),

--- a/sqlite3/lib/src/impl/statement.dart
+++ b/sqlite3/lib/src/impl/statement.dart
@@ -61,10 +61,10 @@ class PreparedStatementImpl implements PreparedStatement {
       return null;
     }
     final columnCount = _bindings.sqlite3_column_count(_stmt);
-    return Iterable.generate(columnCount, (i) {
+    return List.generate(columnCount, (i) {
       final pointer = _bindings.sqlite3_column_table_name!(_stmt, i);
       return pointer.isNullPointer ? null : pointer.readString();
-    }).toList();
+    });
   }
 
   @override

--- a/sqlite3/lib/src/impl/statement.dart
+++ b/sqlite3/lib/src/impl/statement.dart
@@ -55,13 +55,15 @@ class PreparedStatementImpl implements PreparedStatement {
     ];
   }
 
-  List<String> get _tableNames {
+  List<String?>? get _tableNames {
+    if (_bindings.sqlite3_column_table_name == null) {
+      // unsupported
+      return null;
+    }
     final columnCount = _bindings.sqlite3_column_count(_stmt);
-
     return Iterable.generate(columnCount, (i) {
-      final _tableName =
-          _bindings.sqlite3_column_table_name(_stmt, i).readNullableString();
-      return _tableName ?? '';
+      final pointer = _bindings.sqlite3_column_table_name!(_stmt, i);
+      return pointer.isNullPointer ? null : pointer.readString();
     }).toList();
   }
 
@@ -229,7 +231,7 @@ class _ActiveCursorIterator extends IteratingCursor {
   _ActiveCursorIterator(
     this.statement,
     List<String> columnNames,
-    List<String> tableNames,
+    List<String?>? tableNames,
   )   : columnCount = columnNames.length,
         super(columnNames, tableNames);
 

--- a/sqlite3/test/database_test.dart
+++ b/sqlite3/test/database_test.dart
@@ -99,25 +99,33 @@ void main() {
           "INSERT INTO bar(b, a_ref) VALUES ('1', NULL), ('2', 2), ('3', 3);");
 
       final result = database.select(
-          'SELECT *, foo.a > 2 is_greater_than_2 FROM foo INNER JOIN bar ON bar.a_ref = foo.a;');
+        'SELECT *, foo.a > 2 is_greater_than_2 FROM foo'
+        ' INNER JOIN bar bar_alias ON bar_alias.a_ref = foo.a;',
+      );
 
       expect(result, [
         {'a': 2, 'b': '2', 'a_ref': 2, 'is_greater_than_2': 0},
         {'a': 3, 'b': '3', 'a_ref': 3, 'is_greater_than_2': 1},
       ]);
 
-      expect(result.map((row) => row.toTableColumnMap()), [
-        {
-          '': {'is_greater_than_2': 0},
-          'foo': {'a': 2},
-          'bar': {'b': '2', 'a_ref': 2},
-        },
-        {
-          '': {'is_greater_than_2': 1},
-          'foo': {'a': 3},
-          'bar': {'b': '3', 'a_ref': 3},
-        },
-      ]);
+      final tableColumnMaps = result.map((row) => row.toTableColumnMap());
+      if (tableColumnMaps.first == null) {
+        // tables names unsupported in sqlite3 library
+        expect(tableColumnMaps, [null, null]);
+      } else {
+        expect(tableColumnMaps, [
+          {
+            null: {'is_greater_than_2': 0},
+            'foo': {'a': 2},
+            'bar': {'b': '2', 'a_ref': 2},
+          },
+          {
+            null: {'is_greater_than_2': 1},
+            'foo': {'a': 3},
+            'bar': {'b': '3', 'a_ref': 3},
+          },
+        ]);
+      }
     });
   });
 


### PR DESCRIPTION
Hi, thanks for your work.

This creates a new function in `Row`, `toTableColumnMap` similar to the one implemented in the [postgres](https://github.com/isoos/postgresql-dart/blob/b43e6ac8de66ed1e0b8efe52182cff1d81bc104b/lib/src/connection.dart#L571) package. It uses an empty string as a replacement for the null value returned from sqlite. Maybe it would be better to return a `Map<String?, Map<String, dynamic>>`, but I implemented it this way because that's the API in postgres.
Also, I created a helper function in `readNullableString` in the `Utf8Utils` extension which checks for a null pointer before calling `readString`.
There is also a test with an inner join select * and a computed column.

Please, tell me if there is anything else I can help you with. I can make the table name nullability change if you think that's a better API. Thanks.