### PR TITLE
Use systemTemp directory when creating test dbs

### DIFF
--- a/sqlite3/test/database_test.dart
+++ b/sqlite3/test/database_test.dart
@@ -177,7 +177,8 @@ void main() {
   });
 
   test('open read-only', () async {
-    final path = join('.dart_tool', 'sqlite3', 'test', 'read_only.db');
+    final path = Directory.systemTemp.path + '/read_only.db';
+
     // Make sure the path exists
     try {
       await Directory(dirname(path)).create(recursive: true);

--- a/sqlite3/test/errors_test.dart
+++ b/sqlite3/test/errors_test.dart
@@ -6,8 +6,7 @@ import 'package:test/test.dart';
 
 void main() {
   test('open read-only exception', () async {
-    final path =
-        join('.dart_tool', 'sqlite3', 'test', 'read_only_exception.db');
+    final path = Directory.systemTemp.path + '/read_only_exception.db';
 
     try {
       await Directory(dirname(path)).create(recursive: true);
@@ -78,7 +77,8 @@ void main() {
   });
 
   test('busy exception', () async {
-    final path = join('.dart_tool', 'moor_ffi', 'test', 'busy.db');
+    final path = Directory.systemTemp.path + '/busy.db';
+
     // Make sure the path exists
     try {
       await Directory(dirname(path)).create(recursive: true);
@@ -103,7 +103,8 @@ void main() {
   });
 
   test('invalid format', () async {
-    final path = join('.dart_tool', 'moor_ffi', 'test', 'invalid_format.db');
+    final path = Directory.systemTemp.path + '/invalid_format.db';
+
     // Make sure the path exists
     try {
       await Directory(dirname(path)).create(recursive: true);


### PR DESCRIPTION
This allows the tests to run in environments where they cannot write to arbitrary directories.