### PR TITLE
Lower linux cmake minimum version

### DIFF
--- a/sqlite3_flutter_libs/linux/CMakeLists.txt
+++ b/sqlite3_flutter_libs/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10)
 set(PROJECT_NAME "sqlite3_flutter_libs")
 project(${PROJECT_NAME} LANGUAGES C CXX)
 


### PR DESCRIPTION
The current stable Flutter SDK bundles CMake 3.10.2 and it doesn't look like this library is using any new CMake features.

```
Launching lib/main.dart on Linux in debug mode...
Building Linux application...
CMake Error at flutter/ephemeral/.plugin_symlinks/sqlite3_flutter_libs/linux/CMakeLists.txt:1 (cmake_minimum_required):
  CMake 3.14 or higher is required.  You are running version 3.10.2


Exception: Unable to generate build files
```