### PR TITLE
Add test for indexeddb speed

### DIFF
--- a/sqlite3/test/wasm/utils.dart
+++ b/sqlite3/test/wasm/utils.dart
@@ -2,7 +2,7 @@ import 'package:http/http.dart' as http;
 import 'package:sqlite3/wasm.dart';
 import 'package:test/scaffolding.dart';
 
-Future<WasmSqlite3> loadSqlite3() async {
+Future<WasmSqlite3> loadSqlite3([SqliteEnvironment? environment]) async {
   final channel = spawnHybridUri('/test/wasm/asset_server.dart');
   final port = await channel.stream.first as int;
 
@@ -16,5 +16,5 @@ Future<WasmSqlite3> loadSqlite3() async {
         'Could not load module (${response.statusCode} ${response.body})');
   }
 
-  return WasmSqlite3.load(response.bodyBytes);
+  return WasmSqlite3.load(response.bodyBytes, environment);
 }

--- a/sqlite3/test/wasm/wasm_file_system_test.dart
+++ b/sqlite3/test/wasm/wasm_file_system_test.dart
@@ -1,0 +1,61 @@
+@Tags(['wasm'])
+
+import 'package:sqlite3/wasm.dart';
+import 'package:test/test.dart';
+
+import 'utils.dart';
+
+Future<void> main() async {
+  group('indexed db', () {
+    test('with proper persistence', () async {
+      final fileSystem = await IndexedDbFileSystem.open(dbName: 'test');
+      final sqlite3 =
+          await loadSqlite3(SqliteEnvironment(fileSystem: fileSystem));
+      final database = sqlite3.open('test');
+      expect(database.userVersion, 0);
+      database.userVersion = 1;
+      expect(database.userVersion, 1);
+
+      database.execute('CREATE TABLE IF NOT EXISTS users ( '
+          'id INTEGER NOT NULL, '
+          'name TEXT NOT NULL, email TEXT NOT NULL UNIQUE, '
+          'password TEXT NOT NULL, '
+          'user_id INTEGER NOT NULL, '
+          'currentCompanyId INTEGER NULL REFERENCES companies (id), '
+          'PRIMARY KEY (id));');
+
+      final prepared = database.prepare('INSERT INTO users '
+          '(id, name, email, password, user_id) VALUES (?, ?, ?, ?, ?)');
+
+      for (var i = 0; i < 200; i++) {
+        prepared.execute(
+          [
+            BigInt.from(i),
+            'name',
+            'email${BigInt.from(i)}',
+            'password',
+            BigInt.from(i),
+          ],
+        );
+      }
+
+      database.select('SELECT * FROM users').forEach((element) {
+        print(element.values);
+      });
+
+      database.dispose();
+      //await fileSystem.close();
+      await Future<void>.delayed(const Duration(milliseconds: 5000));
+
+      final fileSystem2 = await IndexedDbFileSystem.open(dbName: 'test');
+      final sqlite32 =
+          await loadSqlite3(SqliteEnvironment(fileSystem: fileSystem2));
+      final database2 = sqlite32.open('test');
+      expect(database2.userVersion, 1);
+
+      database2.select('SELECT * FROM users').forEach((element) {
+        print(element.values);
+      });
+    });
+  });
+}


### PR DESCRIPTION
There is a (big) issue with async IndexedDB fs. After inserting a bunch of rows, the persistence take a lot of time. I put 5sec waiting for simulate browser close. When reopen, database will be corrupted. 
Right now, all writes goes in a queue even these writes overlap/overwrites each other. My idea is adding dirty flag for blocks and debounce persistence writes. This way only changed blocks are written at once after bunch of memory writes. 