### PR TITLE
Migrate @staticInterop constructor to factory

### DIFF
--- a/sqlite3/lib/src/wasm/js_interop.dart
+++ b/sqlite3/lib/src/wasm/js_interop.dart
@@ -304,7 +304,7 @@ class ResponseInit {
 @JS()
 @staticInterop
 class Response {
-  external Response(
+  external factory Response(
       Object /* Blob|BufferSource|FormData|ReadableStream|URLSearchParams|UVString */ body,
       ResponseInit init);
 }


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/49350 will disallow generative constructors in @staticInterop classes in the near future.