### PR TITLE
Implementation of Backup API

### DIFF
--- a/sqlite3/CHANGELOG.md
+++ b/sqlite3/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.0-dev
+
+- Add an API for sqlite3's backup API via `Database.backup()`.
+
 ## 1.8.0
 
 - Use a `Finalizer` to automatically dispose databases and statements. As

--- a/sqlite3/assets/sqlite3.h
+++ b/sqlite3/assets/sqlite3.h
@@ -99,12 +99,8 @@ int sqlite3_create_collation_v2(sqlite3 *, sqlite3_char *zName, int eTextRep,
                                 void *pArg, int *xCompare, void *xDestroy);
 
 // Backup
-sqlite3_backup *
-sqlite3_backup_init(sqlite3 *pDestDb,      /* Database to write to */
-                    sqlite3_char *zDestDb, /* Name of database within pDestDb */
-                    sqlite3 *pSrcDb,     /* Database connection to read from */
-                    sqlite3_char *zSrcDb /* Name of database within pSrcDb */
-);
+sqlite3_backup *sqlite3_backup_init(sqlite3 *pDestDb, sqlite3_char *zDestDb,
+                                    sqlite3 *pSrcDb, sqlite3_char *zSrcDb);
 int sqlite3_backup_step(sqlite3_backup *p, int nPage);
 int sqlite3_backup_finish(sqlite3_backup *p);
 int sqlite3_backup_remaining(sqlite3_backup *p);

--- a/sqlite3/assets/sqlite3.h
+++ b/sqlite3/assets/sqlite3.h
@@ -3,12 +3,16 @@
 typedef struct sqlite3_char sqlite3_char;
 typedef struct sqlite3 sqlite3;
 typedef struct sqlite3_stmt sqlite3_stmt;
+typedef struct sqlite3_backup sqlite3_backup;
 
 sqlite3_char *sqlite3_temp_directory;
 
 int sqlite3_open_v2(sqlite3_char *filename, sqlite3 **ppDb, int flags,
                     sqlite3_char *zVfs);
 int sqlite3_close_v2(sqlite3 *db);
+sqlite3_char *sqlite3_db_filename(sqlite3 *db, sqlite3_char *zDbName);
+
+int sqlite3_sleep(int ms);
 
 // Error handling
 int sqlite3_extended_result_codes(sqlite3 *db, int onoff);
@@ -95,3 +99,15 @@ void sqlite3_result_text(sqlite3_context *ctx, sqlite3_char *data, int length,
 // Collations
 int sqlite3_create_collation_v2(sqlite3 *, sqlite3_char *zName, int eTextRep,
                                 void *pArg, int *xCompare, void *xDestroy);
+
+// Backup
+sqlite3_backup *
+sqlite3_backup_init(sqlite3 *pDestDb,      /* Database to write to */
+                    sqlite3_char *zDestDb, /* Name of database within pDestDb */
+                    sqlite3 *pSrcDb,     /* Database connection to read from */
+                    sqlite3_char *zSrcDb /* Name of database within pSrcDb */
+);
+int sqlite3_backup_step(sqlite3_backup *p, int nPage);
+int sqlite3_backup_finish(sqlite3_backup *p);
+int sqlite3_backup_remaining(sqlite3_backup *p);
+int sqlite3_backup_pagecount(sqlite3_backup *p);

--- a/sqlite3/assets/sqlite3.h
+++ b/sqlite3/assets/sqlite3.h
@@ -12,8 +12,6 @@ int sqlite3_open_v2(sqlite3_char *filename, sqlite3 **ppDb, int flags,
 int sqlite3_close_v2(sqlite3 *db);
 sqlite3_char *sqlite3_db_filename(sqlite3 *db, sqlite3_char *zDbName);
 
-int sqlite3_sleep(int ms);
-
 // Error handling
 int sqlite3_extended_result_codes(sqlite3 *db, int onoff);
 int sqlite3_extended_errcode(sqlite3 *db);

--- a/sqlite3/lib/src/ffi/api/database.dart
+++ b/sqlite3/lib/src/ffi/api/database.dart
@@ -23,8 +23,16 @@ abstract class Database extends CommonDatabase {
   List<PreparedStatement> prepareMultiple(String sql,
       {bool persistent = false, bool vtab = true});
 
-  /// Create a backup of the current database into another database
-  /// on memory or disk
+  /// Create a backup of the current database (this) into another database
+  /// ([toDatabase]) on memory or disk.
+  ///
+  /// The returned stream returns a rough estimate on the progress of the
+  /// backup, as a fraction between `0` and `1`. No progress is reported if
+  /// either this or [toDatabase] is an in-memory database.
+  ///
+  /// To simply await the backup operation as a future, call [Stream.drain] on
+  /// the returned stream.
+  ///
   /// See https://www.sqlite.org/c3ref/backup_finish.html
   Stream<double> backup(Database toDatabase);
 }

--- a/sqlite3/lib/src/ffi/api/database.dart
+++ b/sqlite3/lib/src/ffi/api/database.dart
@@ -3,8 +3,6 @@ import 'dart:ffi';
 import '../../common/database.dart';
 import 'statement.dart';
 
-typedef BackupProgressCallback = void Function(double progress);
-
 /// An opened sqlite3 database with `dart:ffi`.
 ///
 /// See [CommonDatabase] for the methods that are available on both the FFI and
@@ -28,5 +26,5 @@ abstract class Database extends CommonDatabase {
   /// Create a backup of the current database into another database
   /// on memory or disk
   /// See https://www.sqlite.org/c3ref/backup_finish.html
-  void backup(Database toDatabase, {BackupProgressCallback? progressCallback});
+  Stream<double> backup(Database toDatabase);
 }

--- a/sqlite3/lib/src/ffi/api/database.dart
+++ b/sqlite3/lib/src/ffi/api/database.dart
@@ -3,6 +3,8 @@ import 'dart:ffi';
 import '../../common/database.dart';
 import 'statement.dart';
 
+typedef BackupProgressCallback = void Function(double progress);
+
 /// An opened sqlite3 database with `dart:ffi`.
 ///
 /// See [CommonDatabase] for the methods that are available on both the FFI and
@@ -22,4 +24,9 @@ abstract class Database extends CommonDatabase {
   @override
   List<PreparedStatement> prepareMultiple(String sql,
       {bool persistent = false, bool vtab = true});
+
+  /// Create a backup of the current database into another database
+  /// on memory or disk
+  /// See https://www.sqlite.org/c3ref/backup_finish.html
+  void backup(Database toDatabase, {BackupProgressCallback? progressCallback});
 }

--- a/sqlite3/lib/src/ffi/api/sqlite3.dart
+++ b/sqlite3/lib/src/ffi/api/sqlite3.dart
@@ -64,6 +64,12 @@ class Sqlite3 implements CommmonSqlite3 {
     return DatabaseImpl.open(_library, ':memory:');
   }
 
+  /// Opens a new in-memory database and copies another database into it
+  /// https://www.sqlite.org/c3ref/backup_finish.html
+  Database copyIntoMemory(Database restoreFrom) {
+    return (openInMemory() as DatabaseImpl)..restore(restoreFrom);
+  }
+
   @override
   String? get tempDirectory {
     final charPtr = _bindings.sqlite3_temp_directory;

--- a/sqlite3/lib/src/ffi/impl/database.dart
+++ b/sqlite3/lib/src/ffi/impl/database.dart
@@ -493,7 +493,7 @@ class DatabaseImpl extends Database {
         final remaining = _bindings.sqlite3_backup_remaining(pBackup);
         final count = _bindings.sqlite3_backup_pagecount(pBackup);
 
-        yield 100 * (count - remaining) / count;
+        yield (count - remaining) / count;
 
         if (returnCode == SqlError.SQLITE_OK ||
             returnCode == SqlError.SQLITE_BUSY ||
@@ -523,6 +523,7 @@ class DatabaseImpl extends Database {
 
   /// Impl only, this should be only called right after opening a new in-memory
   /// database
+  @internal
   void restore(Database fromDatabase) {
     if (!isInMemory()) {
       throw ArgumentError(
@@ -533,13 +534,12 @@ class DatabaseImpl extends Database {
   }
 
   @override
-  Stream<double> backup(Database toDatabase) async* {
+  Stream<double> backup(Database toDatabase) {
     if (isInMemory()) {
-      yield 0;
       _loadOrSaveInMemoryDatabase(toDatabase, true);
-      yield 100;
+      return const Stream.empty();
     } else {
-      yield* _backupDatabase(toDatabase);
+      return _backupDatabase(toDatabase);
     }
   }
 }

--- a/sqlite3/lib/src/ffi/impl/exception.dart
+++ b/sqlite3/lib/src/ffi/impl/exception.dart
@@ -3,20 +3,24 @@ part of 'implementation.dart';
 SqliteException createExceptionRaw(
     Bindings bindings, Pointer<sqlite3> db, int returnCode,
     [String? previousStatement]) {
+// Getting hold of more explanatory error code as SQLITE_IOERR error group
+  // has an extensive list of extended error codes
+  final extendedCode = bindings.sqlite3_extended_errcode(db);
+  return createExceptionFromExtendedCode(
+      bindings, db, returnCode, extendedCode);
+}
+
+SqliteException createExceptionFromExtendedCode(Bindings bindings,
+    Pointer<sqlite3> db, int returnCode, int extendedErrorCode,
+    [String? previousStatement]) {
   // We don't need to free the pointer returned by sqlite3_errmsg: "Memory to
   // hold the error message string is managed internally. The application does
   // not need to worry about freeing the result."
   // https://www.sqlite.org/c3ref/errcode.html
   final dbMessage = bindings.sqlite3_errmsg(db).readString();
 
-  String explanation;
-
-  // Getting hold of more explanatory error code as SQLITE_IOERR error group
-  // has an extensive list of extended error codes
-  final extendedCode = bindings.sqlite3_extended_errcode(db);
-  final errStr = bindings.sqlite3_errstr(extendedCode).readString();
-
-  explanation = '$errStr (code $extendedCode)';
+  final errStr = bindings.sqlite3_errstr(extendedErrorCode).readString();
+  final explanation = '$errStr (code $extendedErrorCode)';
 
   return SqliteException(returnCode, dbMessage, explanation, previousStatement);
 }

--- a/sqlite3/lib/src/ffi/impl/exception.dart
+++ b/sqlite3/lib/src/ffi/impl/exception.dart
@@ -3,11 +3,11 @@ part of 'implementation.dart';
 SqliteException createExceptionRaw(
     Bindings bindings, Pointer<sqlite3> db, int returnCode,
     [String? previousStatement]) {
-// Getting hold of more explanatory error code as SQLITE_IOERR error group
-  // has an extensive list of extended error codes
+  // Getting hold of more explanatory error code as SQLITE_IOERR error group has
+  // an extensive list of extended error codes
   final extendedCode = bindings.sqlite3_extended_errcode(db);
   return createExceptionFromExtendedCode(
-      bindings, db, returnCode, extendedCode);
+      bindings, db, returnCode, extendedCode, previousStatement);
 }
 
 SqliteException createExceptionFromExtendedCode(Bindings bindings,

--- a/sqlite3/lib/src/ffi/impl/implementation.dart
+++ b/sqlite3/lib/src/ffi/impl/implementation.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:meta/meta.dart' show visibleForTesting;
+
 import '../../../sqlite3.dart' hide sqlite3;
 import '../../common/constants.dart';
 import '../../common/impl/finalizer.dart';

--- a/sqlite3/lib/src/ffi/impl/implementation.dart
+++ b/sqlite3/lib/src/ffi/impl/implementation.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:meta/meta.dart' show visibleForTesting;
+import 'package:meta/meta.dart' show internal, visibleForTesting;
 
 import '../../../sqlite3.dart' hide sqlite3;
 import '../../common/constants.dart';

--- a/sqlite3/lib/src/ffi/sqlite3.g.dart
+++ b/sqlite3/lib/src/ffi/sqlite3.g.dart
@@ -84,18 +84,6 @@ class Bindings {
       ffi.Pointer<sqlite3_char> Function(
           ffi.Pointer<sqlite3>, ffi.Pointer<sqlite3_char>)>();
 
-  int sqlite3_sleep(
-    int ms,
-  ) {
-    return _sqlite3_sleep(
-      ms,
-    );
-  }
-
-  late final _sqlite3_sleepPtr =
-      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Int)>>('sqlite3_sleep');
-  late final _sqlite3_sleep = _sqlite3_sleepPtr.asFunction<int Function(int)>();
-
   int sqlite3_extended_result_codes(
     ffi.Pointer<sqlite3> db,
     int onoff,

--- a/sqlite3/lib/src/ffi/sqlite3.g.dart
+++ b/sqlite3/lib/src/ffi/sqlite3.g.dart
@@ -66,6 +66,36 @@ class Bindings {
   late final _sqlite3_close_v2 =
       _sqlite3_close_v2Ptr.asFunction<int Function(ffi.Pointer<sqlite3>)>();
 
+  ffi.Pointer<sqlite3_char> sqlite3_db_filename(
+    ffi.Pointer<sqlite3> db,
+    ffi.Pointer<sqlite3_char> zDbName,
+  ) {
+    return _sqlite3_db_filename(
+      db,
+      zDbName,
+    );
+  }
+
+  late final _sqlite3_db_filenamePtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<sqlite3_char> Function(ffi.Pointer<sqlite3>,
+              ffi.Pointer<sqlite3_char>)>>('sqlite3_db_filename');
+  late final _sqlite3_db_filename = _sqlite3_db_filenamePtr.asFunction<
+      ffi.Pointer<sqlite3_char> Function(
+          ffi.Pointer<sqlite3>, ffi.Pointer<sqlite3_char>)>();
+
+  int sqlite3_sleep(
+    int ms,
+  ) {
+    return _sqlite3_sleep(
+      ms,
+    );
+  }
+
+  late final _sqlite3_sleepPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Int)>>('sqlite3_sleep');
+  late final _sqlite3_sleep = _sqlite3_sleepPtr.asFunction<int Function(int)>();
+
   int sqlite3_extended_result_codes(
     ffi.Pointer<sqlite3> db,
     int onoff,
@@ -961,6 +991,93 @@ class Bindings {
               ffi.Pointer<ffi.Void>,
               ffi.Pointer<ffi.Int>,
               ffi.Pointer<ffi.Void>)>();
+
+  ffi.Pointer<sqlite3_backup> sqlite3_backup_init(
+    ffi.Pointer<sqlite3> pDestDb,
+    ffi.Pointer<sqlite3_char> zDestDb,
+    ffi.Pointer<sqlite3> pSrcDb,
+    ffi.Pointer<sqlite3_char> zSrcDb,
+  ) {
+    return _sqlite3_backup_init(
+      pDestDb,
+      zDestDb,
+      pSrcDb,
+      zSrcDb,
+    );
+  }
+
+  late final _sqlite3_backup_initPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Pointer<sqlite3_backup> Function(
+              ffi.Pointer<sqlite3>,
+              ffi.Pointer<sqlite3_char>,
+              ffi.Pointer<sqlite3>,
+              ffi.Pointer<sqlite3_char>)>>('sqlite3_backup_init');
+  late final _sqlite3_backup_init = _sqlite3_backup_initPtr.asFunction<
+      ffi.Pointer<sqlite3_backup> Function(
+          ffi.Pointer<sqlite3>,
+          ffi.Pointer<sqlite3_char>,
+          ffi.Pointer<sqlite3>,
+          ffi.Pointer<sqlite3_char>)>();
+
+  int sqlite3_backup_step(
+    ffi.Pointer<sqlite3_backup> p,
+    int nPage,
+  ) {
+    return _sqlite3_backup_step(
+      p,
+      nPage,
+    );
+  }
+
+  late final _sqlite3_backup_stepPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(
+              ffi.Pointer<sqlite3_backup>, ffi.Int)>>('sqlite3_backup_step');
+  late final _sqlite3_backup_step = _sqlite3_backup_stepPtr
+      .asFunction<int Function(ffi.Pointer<sqlite3_backup>, int)>();
+
+  int sqlite3_backup_finish(
+    ffi.Pointer<sqlite3_backup> p,
+  ) {
+    return _sqlite3_backup_finish(
+      p,
+    );
+  }
+
+  late final _sqlite3_backup_finishPtr = _lookup<
+          ffi.NativeFunction<ffi.Int Function(ffi.Pointer<sqlite3_backup>)>>(
+      'sqlite3_backup_finish');
+  late final _sqlite3_backup_finish = _sqlite3_backup_finishPtr
+      .asFunction<int Function(ffi.Pointer<sqlite3_backup>)>();
+
+  int sqlite3_backup_remaining(
+    ffi.Pointer<sqlite3_backup> p,
+  ) {
+    return _sqlite3_backup_remaining(
+      p,
+    );
+  }
+
+  late final _sqlite3_backup_remainingPtr = _lookup<
+          ffi.NativeFunction<ffi.Int Function(ffi.Pointer<sqlite3_backup>)>>(
+      'sqlite3_backup_remaining');
+  late final _sqlite3_backup_remaining = _sqlite3_backup_remainingPtr
+      .asFunction<int Function(ffi.Pointer<sqlite3_backup>)>();
+
+  int sqlite3_backup_pagecount(
+    ffi.Pointer<sqlite3_backup> p,
+  ) {
+    return _sqlite3_backup_pagecount(
+      p,
+    );
+  }
+
+  late final _sqlite3_backup_pagecountPtr = _lookup<
+          ffi.NativeFunction<ffi.Int Function(ffi.Pointer<sqlite3_backup>)>>(
+      'sqlite3_backup_pagecount');
+  late final _sqlite3_backup_pagecount = _sqlite3_backup_pagecountPtr
+      .asFunction<int Function(ffi.Pointer<sqlite3_backup>)>();
 }
 
 class sqlite3_char extends ffi.Opaque {}
@@ -968,6 +1085,8 @@ class sqlite3_char extends ffi.Opaque {}
 class sqlite3 extends ffi.Opaque {}
 
 class sqlite3_stmt extends ffi.Opaque {}
+
+class sqlite3_backup extends ffi.Opaque {}
 
 class sqlite3_value extends ffi.Opaque {}
 

--- a/sqlite3/pubspec.yaml
+++ b/sqlite3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite3
 description: Provides lightweight yet convenient bindings to SQLite by using dart:ffi
-version: 1.8.0
+version: 1.9.0-dev
 homepage: https://github.com/simolus3/sqlite3.dart/tree/master/sqlite3
 issue_tracker: https://github.com/simolus3/sqlite3.dart/issues
 

--- a/sqlite3/pubspec.yaml
+++ b/sqlite3/pubspec.yaml
@@ -24,6 +24,7 @@ dev_dependencies:
   shelf_static: ^1.1.0
   stream_channel: ^2.1.0
   test: ^1.17.0
+  test_descriptor: ^2.0.0
 
 dependency_overrides:
   # Only incompatibility is from ffigen

--- a/sqlite3/test/ffi/database_test.dart
+++ b/sqlite3/test/ffi/database_test.dart
@@ -5,6 +5,7 @@ import 'package:path/path.dart';
 import 'package:sqlite3/sqlite3.dart';
 import 'package:sqlite3/src/ffi/impl/implementation.dart';
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 /// Additional tests to `common_database_test.dart` that aren't supported on
 /// the web.
@@ -25,13 +26,7 @@ void main() {
   });
 
   test('open read-only', () async {
-    final path = join('.dart_tool', 'sqlite3', 'test', 'read_only.db');
-    // Make sure the path exists
-    await Directory(dirname(path)).create(recursive: true);
-    // but not the db
-    if (File(path).existsSync()) {
-      await File(path).delete();
-    }
+    final path = d.path('read_only.db');
 
     // Opening a non-existent database should fail
     expect(
@@ -61,20 +56,10 @@ void main() {
   });
 
   group('backup', () {
-    final path = join('.dart_tool', 'sqlite3', 'test', 'test.db');
+    late String path;
 
     setUp(() {
-      Directory(dirname(path)).createSync(recursive: true);
-
-      if (File(path).existsSync()) {
-        File(path).deleteSync();
-      }
-    });
-
-    tearDown(() {
-      if (File(path).existsSync()) {
-        File(path).deleteSync();
-      }
+      path = d.path('test.db');
     });
 
     test('detects if is in-memory database', () {
@@ -146,7 +131,7 @@ void main() {
     });
 
     test('backup disk to disk', () async {
-      final pathFrom = join('.dart_tool', 'sqlite3', 'test', 'test_from.db');
+      final pathFrom = d.path('test_from.db');
       Directory(dirname(pathFrom)).createSync(recursive: true);
 
       if (File(pathFrom).existsSync()) {

--- a/sqlite3/test/ffi/database_test.dart
+++ b/sqlite3/test/ffi/database_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:path/path.dart';
 import 'package:sqlite3/sqlite3.dart';
+import 'package:sqlite3/src/ffi/impl/implementation.dart';
 import 'package:test/test.dart';
 
 /// Additional tests to `common_database_test.dart` that aren't supported on
@@ -57,5 +58,128 @@ void main() {
     expect(db.userVersion, 1);
 
     db.dispose();
+  });
+
+  group('backup', () {
+    final path = join('.dart_tool', 'sqlite3', 'test', 'test.db');
+
+    setUp(() {
+      Directory(dirname(path)).createSync(recursive: true);
+
+      if (File(path).existsSync()) {
+        File(path).deleteSync();
+      }
+    });
+
+    tearDown(() {
+      if (File(path).existsSync()) {
+        File(path).deleteSync();
+      }
+    });
+
+    test('detects if is in-memory database', () {
+      final db1 = sqlite3.open(path) as DatabaseImpl;
+      final db2 = sqlite3.openInMemory() as DatabaseImpl;
+
+      expect(db1.isInMemory(), isFalse);
+      expect(db2.isInMemory(), isTrue);
+
+      db1.dispose();
+      db2.dispose();
+    });
+
+    test('copy in-memory', () {
+      final db1 = sqlite3.openInMemory();
+      db1.execute('CREATE TABLE a(b INTEGER);');
+      db1.execute('INSERT INTO a VALUES (1);');
+
+      //Should not be included in copy
+      final db2 = sqlite3.copyIntoMemory(db1);
+
+      db1.execute('INSERT INTO a VALUES (2);');
+
+      expect(db2.select('SELECT * FROM a'), hasLength(1));
+      expect(db1.select('SELECT * FROM a'), hasLength(2));
+
+      db1.dispose();
+      db2.dispose();
+    });
+
+    test('restore from disk into memory', () {
+      final db1 = sqlite3.open(path);
+      db1.execute('CREATE TABLE a(b INTEGER);');
+      db1.execute('INSERT INTO a VALUES (1);');
+
+      final db2 = sqlite3.copyIntoMemory(db1);
+
+      //Should not be included in copy
+      db1.execute('INSERT INTO a VALUES (2);');
+
+      expect(db2.select('SELECT * FROM a'), hasLength(1));
+      expect(db1.select('SELECT * FROM a'), hasLength(2));
+
+      db1.dispose();
+      db2.dispose();
+    });
+
+    test('backup memory to disk', () {
+      final db1 = sqlite3.openInMemory();
+      db1.execute('CREATE TABLE a(b INTEGER);');
+      db1.execute('INSERT INTO a VALUES (1);');
+
+      final db2 = sqlite3.open(path);
+
+      final progress = <double>[];
+      db1.backup(db2, progressCallback: progress.add);
+      expect(progress, containsAllInOrder(<double>[0, 100]));
+
+      //Should not be included in backup
+      db1.execute('INSERT INTO a VALUES (2);');
+
+      db1.dispose();
+      db2.dispose();
+
+      final db3 = sqlite3.open(path);
+
+      expect(db3.select('SELECT * FROM a'), hasLength(1));
+
+      db3.dispose();
+    });
+
+    test('backup disk to disk', () {
+      final pathFrom = join('.dart_tool', 'sqlite3', 'test', 'test_from.db');
+      Directory(dirname(pathFrom)).createSync(recursive: true);
+
+      if (File(pathFrom).existsSync()) {
+        File(pathFrom).deleteSync();
+      }
+
+      final db1 = sqlite3.open(pathFrom);
+
+      db1.execute('CREATE TABLE a(b INTEGER);');
+      db1.execute('INSERT INTO a VALUES (1);');
+
+      final db2 = sqlite3.open(path);
+
+      final progress = <double>[];
+      db1.backup(db2, progressCallback: progress.add);
+      expect(progress, containsAllInOrder(<double>[100]));
+
+      //Should not be included in backup
+      db1.execute('INSERT INTO a VALUES (2);');
+
+      db1.dispose();
+      db2.dispose();
+
+      final db3 = sqlite3.open(path);
+
+      expect(db3.select('SELECT * FROM a'), hasLength(1));
+
+      db3.dispose();
+
+      if (File(pathFrom).existsSync()) {
+        File(pathFrom).deleteSync();
+      }
+    });
   });
 }

--- a/sqlite3/test/ffi/database_test.dart
+++ b/sqlite3/test/ffi/database_test.dart
@@ -122,16 +122,15 @@ void main() {
       db2.dispose();
     });
 
-    test('backup memory to disk', () {
+    test('backup memory to disk', () async {
       final db1 = sqlite3.openInMemory();
       db1.execute('CREATE TABLE a(b INTEGER);');
       db1.execute('INSERT INTO a VALUES (1);');
 
       final db2 = sqlite3.open(path);
 
-      final progress = <double>[];
-      db1.backup(db2, progressCallback: progress.add);
-      expect(progress, containsAllInOrder(<double>[0, 100]));
+      final progressStream = db1.backup(db2);
+      await expectLater(progressStream, emitsInOrder(<double>[0, 100]));
 
       //Should not be included in backup
       db1.execute('INSERT INTO a VALUES (2);');
@@ -146,7 +145,7 @@ void main() {
       db3.dispose();
     });
 
-    test('backup disk to disk', () {
+    test('backup disk to disk', () async {
       final pathFrom = join('.dart_tool', 'sqlite3', 'test', 'test_from.db');
       Directory(dirname(pathFrom)).createSync(recursive: true);
 
@@ -161,9 +160,8 @@ void main() {
 
       final db2 = sqlite3.open(path);
 
-      final progress = <double>[];
-      db1.backup(db2, progressCallback: progress.add);
-      expect(progress, containsAllInOrder(<double>[100]));
+      final progressStream = db1.backup(db2);
+      await expectLater(progressStream, emitsAnyOf(<double>[100]));
 
       //Should not be included in backup
       db1.execute('INSERT INTO a VALUES (2);');

--- a/sqlite3/test/ffi/database_test.dart
+++ b/sqlite3/test/ffi/database_test.dart
@@ -130,7 +130,7 @@ void main() {
       final db2 = sqlite3.open(path);
 
       final progressStream = db1.backup(db2);
-      await expectLater(progressStream, emitsInOrder(<double>[0, 100]));
+      await expectLater(progressStream, emitsDone);
 
       //Should not be included in backup
       db1.execute('INSERT INTO a VALUES (2);');
@@ -161,7 +161,8 @@ void main() {
       final db2 = sqlite3.open(path);
 
       final progressStream = db1.backup(db2);
-      await expectLater(progressStream, emitsAnyOf(<double>[100]));
+      await expectLater(
+          progressStream, emitsInOrder(<Matcher>[emitsThrough(1), emitsDone]));
 
       //Should not be included in backup
       db1.execute('INSERT INTO a VALUES (2);');

--- a/sqlite3/test/ffi/errors_test.dart
+++ b/sqlite3/test/ffi/errors_test.dart
@@ -4,17 +4,11 @@ import 'dart:io';
 import 'package:path/path.dart';
 import 'package:sqlite3/sqlite3.dart';
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 void main() {
   test('open read-only exception', () async {
-    final path =
-        join('.dart_tool', 'sqlite3', 'test', 'read_only_exception.db');
-
-    await Directory(dirname(path)).create(recursive: true);
-    // but not the db
-    if (File(path).existsSync()) {
-      await File(path).delete();
-    }
+    final path = d.path('read_only_exception.db');
 
     // Opening a non-existent database should fail
     try {
@@ -77,13 +71,7 @@ void main() {
   });
 
   test('busy exception', () async {
-    final path = join('.dart_tool', 'moor_ffi', 'test', 'busy.db');
-    // Make sure the path exists
-    await Directory(dirname(path)).create(recursive: true);
-    // but not the db
-    if (File(path).existsSync()) {
-      await File(path).delete();
-    }
+    final path = d.path('busy.db');
 
     final db1 = sqlite3.open(path);
     final db2 = sqlite3.open(path);
@@ -100,7 +88,7 @@ void main() {
   });
 
   test('invalid format', () async {
-    final path = join('.dart_tool', 'moor_ffi', 'test', 'invalid_format.db');
+    final path = d.path('invalid_format.db');
     // Make sure the path exists
     await Directory(dirname(path)).create(recursive: true);
     await File(path).writeAsString('not a database file');

--- a/sqlite3/test/ffi/sqlite3_test.dart
+++ b/sqlite3/test/ffi/sqlite3_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:sqlite3/sqlite3.dart';
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 void main() {
   test('get version', () {
@@ -11,14 +12,14 @@ void main() {
   });
 
   test('sqlite3_temp_directory', () {
-    final dir = Directory('.dart_tool/sqlite3/tmp');
+    final dir = Directory(d.path('sqlite3/tmp'));
     dir.createSync(recursive: true);
     final old = sqlite3.tempDirectory;
 
     try {
       sqlite3.tempDirectory = dir.absolute.path;
 
-      final db = sqlite3.open('.dart_tool/tmp.db');
+      final db = sqlite3.open(d.path('tmp.db'));
       db
         ..execute('PRAGMA temp_store = FILE;')
         ..execute('CREATE TEMP TABLE my_tbl (foo, bar);')


### PR DESCRIPTION
This PR adds support for the SQLite Backup API (https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupinit) for ffi.

It supports backup/restore from/to memory/disk databases. The implementation follows the official examples: https://www.sqlite.org/backup.html

This can be also useful for testing, since its very easy now to load a prepared database from disk into memory and apply additional tests on it.