### PR TITLE
Setup integration tests on Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,13 +227,17 @@ jobs:
       - name: sqlite3 driver tests
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: "flutter pub get && flutter test integration_test"
+          run: |
+            flutter pub get
+            flutter test integration_test
           working-directory: integration_tests/flutter_libs
       
       - name: sqlcipher driver tests
         uses: GabrielBB/xvfb-action@v1
         with:
-          run: "flutter pub get && flutter test integration_test"
+          run: |
+            flutter pub get
+            flutter test integration_test
           working-directory: integration_tests/sqlcipher_flutter
 
   # Shamelessly stolen from https://medium.com/flutter-community/run-flutter-driver-tests-on-github-actions-13c639c7e4ab
@@ -276,13 +280,9 @@ jobs:
           flutter --version
 
       - name: sqlite3 driver tests
-        run: |
-          flutter pub get
-          flutter test integration_test
+        run: "flutter pub get && flutter test integration_test"
         working-directory: integration_tests/flutter_libs
 
       - name: sqlcipher driver tests
-        run: |
-          flutter pub get
-          flutter test integration_test
+        run: "flutter pub get && flutter test integration_test"
         working-directory: integration_tests/sqlcipher_flutter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -276,9 +276,13 @@ jobs:
           flutter --version
 
       - name: sqlite3 driver tests
-        run: "flutter pub get && flutter test integration_test"
+        run: |
+          flutter pub get
+          flutter test integration_test
         working-directory: integration_tests/flutter_libs
 
       - name: sqlcipher driver tests
-        run: "flutter pub get && flutter test integration_test"
+        run: |
+          flutter pub get
+          flutter test integration_test
         working-directory: integration_tests/sqlcipher_flutter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -225,20 +225,12 @@ jobs:
           flutter --version
       
       - name: sqlite3 driver tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: |
-            flutter pub get
-            flutter test integration_test
-          working-directory: integration_tests/flutter_libs
-      
+        run: "flutter pub get && xvfb-run -a flutter test integration_test"
+        working-directory: integration_tests/flutter_libs
+
       - name: sqlcipher driver tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: |
-            flutter pub get
-            flutter test integration_test
-          working-directory: integration_tests/sqlcipher_flutter
+        run: "flutter pub get && xvfb-run -a flutter test integration_test"
+        working-directory: integration_tests/sqlcipher_flutter
 
   # Shamelessly stolen from https://medium.com/flutter-community/run-flutter-driver-tests-on-github-actions-13c639c7e4ab
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -211,25 +211,30 @@ jobs:
 #          script: flutter test integration_test
 #          working-directory: "integration_tests/${{ matrix.test }}"
 
-  # Linux integration tests don't work because there's no display on GitHub actions
-  # I don't know if this can be faked easily to get `flutter run -d linux` to work.
-#  integration_test_linux:
-#    needs: [test]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: subosito/flutter-action@v1
-#        with:
-#          channel: dev
-#      - name: Setup Flutter
-#        run: |
-#          flutter config --enable-linux-desktop
-#          sudo apt-get update -y
-#          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
-#          flutter --version
-#      - name: sqlite3 driver tests
-#        run: "flutter pub get && flutter pub run test_driver/integration_test.dart linux"
-#        working-directory: integration_tests/flutter_libs
+  integration_test_linux:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: subosito/flutter-action@v2.4.0
+      - name: Setup Flutter
+        run: |
+          flutter config --enable-linux-desktop
+          sudo apt-get update -y
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
+          flutter --version
+      
+      - name: sqlite3 driver tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: "flutter pub get && flutter test integration_test"
+          working-directory: integration_tests/flutter_libs
+      
+      - name: sqlcipher driver tests
+        uses: GabrielBB/xvfb-action@v1
+        with:
+          run: "flutter pub get && flutter test integration_test"
+          working-directory: integration_tests/sqlcipher_flutter
 
   # Shamelessly stolen from https://medium.com/flutter-community/run-flutter-driver-tests-on-github-actions-13c639c7e4ab
 

--- a/sqlite3/lib/src/wasm/js_interop.dart
+++ b/sqlite3/lib/src/wasm/js_interop.dart
@@ -297,7 +297,8 @@ class ResponseInit {
 @staticInterop
 class Response {
   external factory Response(
-      Object /* Blob|BufferSource|FormData|ReadableStream|URLSearchParams|UVString */ body,
+      Object /* Blob|BufferSource|FormData|ReadableStream|URLSearchParams|UVString */
+          body,
       ResponseInit init);
 }
 


### PR DESCRIPTION
At first I wanted to use [xvfb-action](https://github.com/GabrielBB/xvfb-action), but then I've discovered that it is not maintained anymore. So I switched to `xvfb-run` command which is pre-instlled on `ubuntu-latest` according to this [PR](https://github.com/aioutecism/amVim-for-VSCode/pull/315).