### PR TITLE
Fix platform dependent path

### DIFF
--- a/sqlite3/README.md
+++ b/sqlite3/README.md
@@ -57,6 +57,7 @@ For instance, if you release your own `sqlite3.so` next to your application, you
 import 'dart:ffi';
 import 'dart:io';
 
+import 'package:path/path.dart';
 import 'package:sqlite3/open.dart';
 import 'package:sqlite3/sqlite3.dart';
 
@@ -70,7 +71,7 @@ void main() {
 
 DynamicLibrary _openOnLinux() {
   final scriptDir = File(Platform.script.toFilePath()).parent;
-  final libraryNextToScript = File('${scriptDir.path}/sqlite3.so');
+  final libraryNextToScript = File(join(scriptDir.path, 'sqlite3.so'));
   return DynamicLibrary.open(libraryNextToScript.path);
 }
 ```


### PR DESCRIPTION
I know the example is for Linux (`_openOnLinux`), but even then it might be better to use `join()`, so that it can be easily updated for Windows.

On Windows, the problem would be with slashes vs backslashes in the path.