### PR TITLE
Add support for Gradle 8+

### DIFF
--- a/sqlcipher_flutter_libs/android/build.gradle
+++ b/sqlcipher_flutter_libs/android/build.gradle
@@ -4,18 +4,18 @@ version '1.0'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.2.2'
     }
 }
 
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -23,6 +23,11 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 28
+
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'eu.simonbinder.sqlite3_flutter_libs'
+    }
 
     defaultConfig {
         minSdkVersion 16

--- a/sqlcipher_flutter_libs/android/gradle/wrapper/gradle-wrapper.properties
+++ b/sqlcipher_flutter_libs/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue May 09 11:17:21 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip

--- a/sqlite3_flutter_libs/android/build.gradle
+++ b/sqlite3_flutter_libs/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath 'com.android.tools.build:gradle:7.2.2'
     }
 }
 
@@ -17,6 +17,11 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 32
+
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'eu.simonbinder.sqlite3_flutter_libs'
+    }
 
     defaultConfig {
         minSdkVersion 16

--- a/sqlite3_flutter_libs/android/gradle/wrapper/gradle-wrapper.properties
+++ b/sqlite3_flutter_libs/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue May 09 11:18:32 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip


### PR DESCRIPTION
## Description

Hello, currently the flutter plugins don't build when Gradle 8+ is used. That is because the property `namespace` is mandatory.
I included the namespace property with backwards compatibility.