### PR TITLE
Update SQLCipher version to 4.5.4

### DIFF
--- a/sqlcipher_flutter_libs/CHANGELOG.md
+++ b/sqlcipher_flutter_libs/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.6
+
+- Upgrade `SQLCipher` to version `4.5.4` (https://www.zetetic.net/blog/2023/04/27/sqlcipher-4.5.4-release).
+
 ## 0.5.5
 
 - Support Android projects built with Gradle 8.

--- a/sqlcipher_flutter_libs/android/build.gradle
+++ b/sqlcipher_flutter_libs/android/build.gradle
@@ -38,5 +38,5 @@ android {
 }
 
 dependencies {
-    implementation "net.zetetic:android-database-sqlcipher:4.5.2"
+    implementation "net.zetetic:android-database-sqlcipher:4.5.4"
 }

--- a/sqlcipher_flutter_libs/ios/sqlcipher_flutter_libs.podspec
+++ b/sqlcipher_flutter_libs/ios/sqlcipher_flutter_libs.podspec
@@ -17,7 +17,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
 
-  s.dependency 'SQLCipher', '~> 4.5.2'
+  s.dependency 'SQLCipher', '~> 4.5.4'
   
   s.platform = :ios, '8.0'
 

--- a/sqlcipher_flutter_libs/linux/CMakeLists.txt
+++ b/sqlcipher_flutter_libs/linux/CMakeLists.txt
@@ -10,7 +10,7 @@ set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
 # Using a prebuilt sqlcipher amalgation because building it requires TCL/TK which no one has.
-file(DOWNLOAD "https://storage.googleapis.com/simon-public-euw3/assets/sqlcipher/v4_5_2.c" "${CMAKE_CURRENT_BINARY_DIR}/sqlcipher.c" EXPECTED_HASH SHA512=eb9fe6d8f01725e16f4a0bec45de8fa7f1eefcb341f03a45ad073682407d02d5ce8c8667fe48a92d23a7f600ab45fb0ed15288842f5665591298355e7a9e53d4)
+file(DOWNLOAD "https://storage.googleapis.com/simon-public-euw3/assets/sqlcipher/v4_5_4.c" "${CMAKE_CURRENT_BINARY_DIR}/sqlcipher.c" EXPECTED_HASH SHA512=eb9fe6d8f01725e16f4a0bec45de8fa7f1eefcb341f03a45ad073682407d02d5ce8c8667fe48a92d23a7f600ab45fb0ed15288842f5665591298355e7a9e53d4)
 
 add_library(${PLUGIN_NAME} SHARED
   "sqlite3_flutter_libs_plugin.cc"

--- a/sqlcipher_flutter_libs/macos/sqlcipher_flutter_libs.podspec
+++ b/sqlcipher_flutter_libs/macos/sqlcipher_flutter_libs.podspec
@@ -17,7 +17,7 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'FlutterMacOS'
 
-  s.dependency 'SQLCipher', '~> 4.5.2'
+  s.dependency 'SQLCipher', '~> 4.5.4'
   
   s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 

--- a/sqlcipher_flutter_libs/pubspec.yaml
+++ b/sqlcipher_flutter_libs/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlcipher_flutter_libs
 description: Flutter plugin to include native SQLCipher libraries in your app
-version: 0.5.5
+version: 0.5.6
 homepage: https://github.com/simolus3/sqlite3.dart/tree/main/sqlcipher_flutter_libs
 issue_tracker: https://github.com/simolus3/sqlite3.dart/issues
 

--- a/sqlcipher_flutter_libs/windows/CMakeLists.txt
+++ b/sqlcipher_flutter_libs/windows/CMakeLists.txt
@@ -27,7 +27,7 @@ set(OPENSSL_USE_STATIC_LIBS TRUE)
 find_package(OpenSSL REQUIRED)
 
 # Using a prebuilt sqlcipher amalgation because building it requires TCL/TK which no one has.
-file(DOWNLOAD "https://storage.googleapis.com/simon-public-euw3/assets/sqlcipher/v4_5_2.c" "${CMAKE_CURRENT_BINARY_DIR}/sqlcipher.c" EXPECTED_HASH SHA512=eb9fe6d8f01725e16f4a0bec45de8fa7f1eefcb341f03a45ad073682407d02d5ce8c8667fe48a92d23a7f600ab45fb0ed15288842f5665591298355e7a9e53d4)
+file(DOWNLOAD "https://storage.googleapis.com/simon-public-euw3/assets/sqlcipher/v4_5_4.c" "${CMAKE_CURRENT_BINARY_DIR}/sqlcipher.c" EXPECTED_HASH SHA512=eb9fe6d8f01725e16f4a0bec45de8fa7f1eefcb341f03a45ad073682407d02d5ce8c8667fe48a92d23a7f600ab45fb0ed15288842f5665591298355e7a9e53d4)
 
 add_library(sqlite3 SHARED "sqlite3_flutter.c")
 target_include_directories(sqlite3 PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
Previous one was 4.5.2

Release notes: https://www.zetetic.net/blog/2023/04/27/sqlcipher-4.5.4-release/

Probably CI will fail for Linux and Windows because the source code was not uploaded to the `simon-public-euw3` bucket.