### PR TITLE
Add option to enable/disable double quotes as literals

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
 
     - name: Web tests
       run: |
-        curl https://storage.googleapis.com/simon-public-euw3/assets/sqlite3/wasm/2.0.0/sqlite3.wasm -o example/web/sqlite3.wasm
+        curl https://storage.googleapis.com/simon-public-euw3/assets/sqlite3/wasm/2.1.0/sqlite3.wasm -o example/web/sqlite3.wasm
         dart test -P web -r expanded
       # If browsers behave differently on different platforms, surely that's not our fault...
       # So, only run browser tests on Linux to be faster.

--- a/sqlite3/CHANGELOG.md
+++ b/sqlite3/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+- Add `config` getter to `CommonDatabase` to access `sqlite3_db_config`.
+
 ## 2.0.0
 
 - __Breaking__: The WASM implementation no longer registers a default virtual

--- a/sqlite3/assets/sqlite3.h
+++ b/sqlite3/assets/sqlite3.h
@@ -116,3 +116,6 @@ int sqlite3_backup_pagecount(sqlite3_backup *p);
 
 // Extensions
 int sqlite3_auto_extension(void *xEntryPoint);
+
+// Database configuration
+int sqlite3_db_config(sqlite3 *db, int op, ...);

--- a/sqlite3/assets/wasm/helpers.c
+++ b/sqlite3/assets/wasm/helpers.c
@@ -228,3 +228,7 @@ SQLITE_API int dart_sqlite3_create_collation(sqlite3 *db, const char *zName,
   return sqlite3_create_collation_v2(db, zName, eTextRep, (void *)id,
                                      &dartXCompare, &dartForgetAboutFunction);
 }
+
+SQLITE_API int dart_sqlite3_db_config_int(sqlite3 *db, int op, int arg) {
+  return sqlite3_db_config(db, op, arg);
+}

--- a/sqlite3/ffigen.yaml
+++ b/sqlite3/ffigen.yaml
@@ -13,5 +13,8 @@ macros:
   include: ['sqlite3.*']
 functions:
   include: ['sqlite3.*']
+  variadic-arguments:
+    sqlite3_db_config:
+      - [int, int*]
 globals:
   include: ['sqlite3.*']

--- a/sqlite3/lib/src/constants.dart
+++ b/sqlite3/lib/src/constants.dart
@@ -528,3 +528,7 @@ const SQLITE_UPDATE = 23;
 
 final bigIntMinValue64 = BigInt.parse('-9223372036854775808');
 final bigIntMaxValue64 = BigInt.parse('9223372036854775807');
+
+// Connection config options https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
+const SQLITE_DBCONFIG_DQS_DML = 1013;
+const SQLITE_DBCONFIG_DQS_DDL = 1014;

--- a/sqlite3/lib/src/database.dart
+++ b/sqlite3/lib/src/database.dart
@@ -8,7 +8,12 @@ import 'constants.dart';
 /// An opened sqlite3 database.
 abstract class CommonDatabase {
   /// Configuration for the database connection.
-  DatabaseOptions get options;
+  ///
+  /// __Note__: On the web, the [DatabaseConfig] class only works when using a
+  /// version of `sqlite3.wasm` shipped with version 2.1.0 of the `sqlite3`
+  /// Dart package. In previous WASM builds, all setters on the config will
+  /// throw an exception.
+  DatabaseConfig get config;
 
   /// The application defined version of this database.
   abstract int userVersion;
@@ -212,7 +217,7 @@ final class SqliteUpdate {
 ///
 /// More information: https://www.sqlite.org/c3ref/db_config.html
 /// Available options are documented in https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
-abstract base class DatabaseOptions {
+abstract base class DatabaseConfig {
   /// Update configuration that accepts an int value.
   /// Would throw when the internal C call returns a non-zero value.
   void setIntConfig(int key, int configValue);
@@ -221,9 +226,7 @@ abstract base class DatabaseOptions {
   ///
   /// More information: https://www.sqlite.org/compile.html#dqs
   set doubleQuotedStringLiterals(bool value) {
-    // 3 allows double quotes in DDL and DML
-    // 0 disallows double quotes in DDL and DML
-    final dqsValue = value ? 3 : 0;
+    final dqsValue = value ? 1 : 0;
     setIntConfig(SQLITE_DBCONFIG_DQS_DML, dqsValue);
     setIntConfig(SQLITE_DBCONFIG_DQS_DDL, dqsValue);
   }

--- a/sqlite3/lib/src/database.dart
+++ b/sqlite3/lib/src/database.dart
@@ -214,10 +214,10 @@ final class SqliteUpdate {
 /// Available options are documented in https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
 abstract base class DatabaseOptions {
   /// Update configuration that accepts an int value.
+  /// Would throw when the internal C call returns a non-zero value.
   void setIntConfig(int key, int configValue);
 
   /// Enable or disable SQLite support for double quotes as string literals.
-  /// Would throw when the internal C call returns a non-zero value.
   ///
   /// More information: https://www.sqlite.org/compile.html#dqs
   set doubleQuotedStringLiterals(bool value) {

--- a/sqlite3/lib/src/database.dart
+++ b/sqlite3/lib/src/database.dart
@@ -7,6 +7,7 @@ import 'constants.dart';
 
 /// An opened sqlite3 database.
 abstract class CommonDatabase {
+  /// Configuration for the database connection.
   DatabaseOptions get options;
 
   /// The application defined version of this database.
@@ -207,12 +208,23 @@ final class SqliteUpdate {
   }
 }
 
+/// Make configuration changes to the database connection.
+///
+/// More information: https://www.sqlite.org/c3ref/db_config.html
+/// Available options are documented in https://www.sqlite.org/c3ref/c_dbconfig_defensive.html
 abstract base class DatabaseOptions {
-  // Would throw when the internal C call returns a non-zero value.
+  /// Update configuration that accepts an int value.
   void setIntConfig(int key, int configValue);
 
+  /// Enable or disable SQLite support for double quotes as string literals.
+  /// Would throw when the internal C call returns a non-zero value.
+  ///
+  /// More information: https://www.sqlite.org/compile.html#dqs
   set doubleQuotedStringLiterals(bool value) {
-    setIntConfig(SQLITE_DBCONFIG_DQS_DML, value ? 1 : 0);
-    setIntConfig(SQLITE_DBCONFIG_DQS_DDL, value ? 1 : 0);
+    // 3 allows double quotes in DDL and DML
+    // 0 disallows double quotes in DDL and DML
+    final dqsValue = value ? 3 : 0;
+    setIntConfig(SQLITE_DBCONFIG_DQS_DML, dqsValue);
+    setIntConfig(SQLITE_DBCONFIG_DQS_DDL, dqsValue);
   }
 }

--- a/sqlite3/lib/src/database.dart
+++ b/sqlite3/lib/src/database.dart
@@ -3,9 +3,12 @@ import 'package:meta/meta.dart';
 import 'functions.dart';
 import 'result_set.dart';
 import 'statement.dart';
+import 'constants.dart';
 
 /// An opened sqlite3 database.
 abstract class CommonDatabase {
+  DatabaseOptions get options;
+
   /// The application defined version of this database.
   abstract int userVersion;
 
@@ -157,8 +160,6 @@ abstract class CommonDatabase {
     bool directOnly = true,
   });
 
-  void configDoubleQuotedStringLiterals({required bool enable});
-
   /// Closes this database and releases associated resources.
   void dispose();
 }
@@ -203,5 +204,15 @@ final class SqliteUpdate {
   @override
   String toString() {
     return 'SqliteUpdate: $kind on $tableName, rowid = $rowId';
+  }
+}
+
+abstract base class DatabaseOptions {
+  // Would throw when the internal C call returns a non-zero value.
+  void setIntConfig(int key, int configValue);
+
+  set doubleQuotedStringLiterals(bool value) {
+    setIntConfig(SQLITE_DBCONFIG_DQS_DML, value ? 1 : 0);
+    setIntConfig(SQLITE_DBCONFIG_DQS_DDL, value ? 1 : 0);
   }
 }

--- a/sqlite3/lib/src/database.dart
+++ b/sqlite3/lib/src/database.dart
@@ -157,6 +157,8 @@ abstract class CommonDatabase {
     bool directOnly = true,
   });
 
+  void configDoubleQuotedStringLiterals({required bool enable});
+
   /// Closes this database and releases associated resources.
   void dispose();
 }

--- a/sqlite3/lib/src/ffi/bindings.dart
+++ b/sqlite3/lib/src/ffi/bindings.dart
@@ -267,6 +267,16 @@ final class FfiDatabase extends RawSqliteDatabase {
     );
   }
 
+  int sqlite3_db_config(int op, int value) {
+    final result = bindings.bindings.sqlite3_db_config(
+      db,
+      op,
+      value,
+      nullPtr(),
+    );
+    return result;
+  }
+
   @override
   RawStatementCompiler newCompiler(List<int> utf8EncodedSql) {
     return FfiStatementCompiler(this, allocateBytes(utf8EncodedSql));

--- a/sqlite3/lib/src/ffi/bindings.dart
+++ b/sqlite3/lib/src/ffi/bindings.dart
@@ -267,6 +267,7 @@ final class FfiDatabase extends RawSqliteDatabase {
     );
   }
 
+  @override
   int sqlite3_db_config(int op, int value) {
     final result = bindings.bindings.sqlite3_db_config(
       db,

--- a/sqlite3/lib/src/ffi/sqlite3.g.dart
+++ b/sqlite3/lib/src/ffi/sqlite3.g.dart
@@ -1181,6 +1181,33 @@ class Bindings {
           'sqlite3_auto_extension');
   late final _sqlite3_auto_extension = _sqlite3_auto_extensionPtr
       .asFunction<int Function(ffi.Pointer<ffi.Void>)>();
+
+  int sqlite3_db_config(
+    ffi.Pointer<sqlite3> db,
+    int op,
+    int va,
+    ffi.Pointer<ffi.Int> va1,
+  ) {
+    return _sqlite3_db_config(
+      db,
+      op,
+      va,
+      va1,
+    );
+  }
+
+  late final _sqlite3_db_configPtr = _lookup<
+      ffi.NativeFunction<
+          ffi.Int Function(
+              ffi.Pointer<sqlite3>,
+              ffi.Int,
+              ffi.VarArgs<
+                  (
+                    ffi.Int,
+                    ffi.Pointer<ffi.Int>,
+                  )>)>>('sqlite3_db_config');
+  late final _sqlite3_db_config = _sqlite3_db_configPtr.asFunction<
+      int Function(ffi.Pointer<sqlite3>, int, int, ffi.Pointer<ffi.Int>)>();
 }
 
 final class sqlite3_char extends ffi.Opaque {}

--- a/sqlite3/lib/src/implementation/bindings.dart
+++ b/sqlite3/lib/src/implementation/bindings.dart
@@ -103,6 +103,8 @@ abstract base class RawSqliteDatabase {
     required RawXFinal xValue,
     required RawXStep xInverse,
   });
+
+  int sqlite3_db_config(int op, int value);
 }
 
 /// A stateful wrapper around multiple `sqlite3_prepare` invocations.

--- a/sqlite3/lib/src/implementation/database.dart
+++ b/sqlite3/lib/src/implementation/database.dart
@@ -448,6 +448,23 @@ base class DatabaseImplementation implements CommonDatabase {
       isBroadcast: true,
     );
   }
+
+  @override
+  void configDoubleQuotedStringLiterals({required bool enable}) {
+    final value = enable ? 1 : 0;
+
+    final resultDML =
+        database.sqlite3_db_config(SQLITE_DBCONFIG_DQS_DML, value);
+    if (resultDML != SqlError.SQLITE_OK) {
+      throwException(this, resultDML);
+    }
+
+    final resultDDL =
+        database.sqlite3_db_config(SQLITE_DBCONFIG_DQS_DDL, value);
+    if (resultDDL != SqlError.SQLITE_OK) {
+      throwException(this, resultDDL);
+    }
+  }
 }
 
 extension on RawSqliteContext {

--- a/sqlite3/lib/src/implementation/database.dart
+++ b/sqlite3/lib/src/implementation/database.dart
@@ -62,6 +62,9 @@ base class DatabaseImplementation implements CommonDatabase {
   var _isClosed = false;
 
   @override
+  DatabaseOptions get options => DatabaseOptionsImplementation(this);
+
+  @override
   int get userVersion {
     final stmt = prepare('PRAGMA user_version;');
     try {
@@ -448,23 +451,6 @@ base class DatabaseImplementation implements CommonDatabase {
       isBroadcast: true,
     );
   }
-
-  @override
-  void configDoubleQuotedStringLiterals({required bool enable}) {
-    final value = enable ? 1 : 0;
-
-    final resultDML =
-        database.sqlite3_db_config(SQLITE_DBCONFIG_DQS_DML, value);
-    if (resultDML != SqlError.SQLITE_OK) {
-      throwException(this, resultDML);
-    }
-
-    final resultDDL =
-        database.sqlite3_db_config(SQLITE_DBCONFIG_DQS_DDL, value);
-    if (resultDDL != SqlError.SQLITE_OK) {
-      throwException(this, resultDDL);
-    }
-  }
 }
 
 extension on RawSqliteContext {
@@ -566,5 +552,19 @@ class ValueList extends ListBase<Object?> {
   @override
   void operator []=(int index, Object? value) {
     throw ArgumentError('The argument list is unmodifiable');
+  }
+}
+
+base class DatabaseOptionsImplementation extends DatabaseOptions {
+  final DatabaseImplementation database;
+
+  DatabaseOptionsImplementation(this.database);
+
+  @override
+  void setIntConfig(int key, int configValue) {
+    final resultDML = database.database.sqlite3_db_config(key, configValue);
+    if (resultDML != SqlError.SQLITE_OK) {
+      throwException(database, resultDML);
+    }
   }
 }

--- a/sqlite3/lib/src/implementation/database.dart
+++ b/sqlite3/lib/src/implementation/database.dart
@@ -62,7 +62,7 @@ base class DatabaseImplementation implements CommonDatabase {
   var _isClosed = false;
 
   @override
-  DatabaseOptions get options => DatabaseOptionsImplementation(this);
+  DatabaseConfig get config => DatabaseConfigImplementation(this);
 
   @override
   int get userVersion {
@@ -555,10 +555,10 @@ class ValueList extends ListBase<Object?> {
   }
 }
 
-base class DatabaseOptionsImplementation extends DatabaseOptions {
+final class DatabaseConfigImplementation extends DatabaseConfig {
   final DatabaseImplementation database;
 
-  DatabaseOptionsImplementation(this.database);
+  DatabaseConfigImplementation(this.database);
 
   @override
   void setIntConfig(int key, int configValue) {

--- a/sqlite3/lib/src/wasm/bindings.dart
+++ b/sqlite3/lib/src/wasm/bindings.dart
@@ -245,6 +245,11 @@ final class WasmDatabase extends RawSqliteDatabase {
 
     bindings.dart_sqlite3_updates(db, hook != null ? 1 : -1);
   }
+
+  @override
+  int sqlite3_db_config(int op, int value) {
+    return bindings.sqlite3_db_config(db, op, value);
+  }
 }
 
 final class WasmStatementCompiler extends RawStatementCompiler {

--- a/sqlite3/lib/src/wasm/wasm_interop.dart
+++ b/sqlite3/lib/src/wasm/wasm_interop.dart
@@ -77,8 +77,9 @@ class WasmBindings {
       _sqlite3_value_bytes,
       _sqlite3_value_text,
       _sqlite3_value_blob,
-      _sqlite3_aggregate_context,
-      _sqlite3_db_config;
+      _sqlite3_aggregate_context;
+
+  final Function? _sqlite3_db_config;
 
   final Global _sqlite3_temp_directory;
 
@@ -151,7 +152,7 @@ class WasmBindings {
         _sqlite3_value_blob = instance.functions['sqlite3_value_blob']!,
         _sqlite3_aggregate_context =
             instance.functions['sqlite3_aggregate_context']!,
-        _sqlite3_db_config = instance.functions['sqlite3_db_config']!,
+        _sqlite3_db_config = instance.functions['dart_sqlite3_db_config_int'],
         _sqlite3_temp_directory = instance.globals['sqlite3_temp_directory']! {
     values.bindings = this;
   }
@@ -404,8 +405,14 @@ class WasmBindings {
   int sqlite3_last_insert_rowid(Pointer db) =>
       JsBigInt(_sqlite3_last_insert_rowid(db) as Object).asDartInt;
 
-  int sqlite3_db_config(Pointer db, int op, int value) =>
-      _sqlite3_db_config(db, op, value) as int;
+  int sqlite3_db_config(Pointer db, int op, int value) {
+    final function = _sqlite3_db_config;
+    if (function != null) {
+      return function(db, op, value) as int;
+    } else {
+      return 1; // Not supported with this wasm build
+    }
+  }
 
   Pointer get sqlite3_temp_directory {
     return _sqlite3_temp_directory.value;

--- a/sqlite3/lib/src/wasm/wasm_interop.dart
+++ b/sqlite3/lib/src/wasm/wasm_interop.dart
@@ -77,7 +77,8 @@ class WasmBindings {
       _sqlite3_value_bytes,
       _sqlite3_value_text,
       _sqlite3_value_blob,
-      _sqlite3_aggregate_context;
+      _sqlite3_aggregate_context,
+      _sqlite3_db_config;
 
   final Global _sqlite3_temp_directory;
 
@@ -150,6 +151,7 @@ class WasmBindings {
         _sqlite3_value_blob = instance.functions['sqlite3_value_blob']!,
         _sqlite3_aggregate_context =
             instance.functions['sqlite3_aggregate_context']!,
+        _sqlite3_db_config = instance.functions['sqlite3_db_config']!,
         _sqlite3_temp_directory = instance.globals['sqlite3_temp_directory']! {
     values.bindings = this;
   }
@@ -401,6 +403,9 @@ class WasmBindings {
 
   int sqlite3_last_insert_rowid(Pointer db) =>
       JsBigInt(_sqlite3_last_insert_rowid(db) as Object).asDartInt;
+
+  int sqlite3_db_config(Pointer db, int op, int value) =>
+      _sqlite3_db_config(db, op, value) as int;
 
   Pointer get sqlite3_temp_directory {
     return _sqlite3_temp_directory.value;

--- a/sqlite3/pubspec.yaml
+++ b/sqlite3/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite3
 description: Provides lightweight yet convenient bindings to SQLite by using dart:ffi
-version: 2.0.0
+version: 2.1.0
 homepage: https://github.com/simolus3/sqlite3.dart/tree/main/sqlite3
 issue_tracker: https://github.com/simolus3/sqlite3.dart/issues
 

--- a/sqlite3/test/common/database.dart
+++ b/sqlite3/test/common/database.dart
@@ -741,7 +741,7 @@ void testDatabase(
     const query = 'SELECT "foo" AS double, \'bar\' AS single';
 
     test('enable', () {
-      database.configDoubleQuotedStringLiterals(enable: true);
+      database.options.doubleQuotedStringLiterals = true;
 
       expect(database.select(query), [
         {
@@ -752,7 +752,7 @@ void testDatabase(
     });
 
     test('disable', () {
-      database.configDoubleQuotedStringLiterals(enable: false);
+      database.options.doubleQuotedStringLiterals = false;
 
       expect(
         () => database.select(query),

--- a/sqlite3/test/common/database.dart
+++ b/sqlite3/test/common/database.dart
@@ -736,6 +736,30 @@ void testDatabase(
       ]);
     });
   });
+
+  group('double quotes as literals', () {
+    const query = 'SELECT "foo" AS double, \'bar\' AS single';
+
+    test('enable', () {
+      database.configDoubleQuotedStringLiterals(enable: true);
+
+      expect(database.select(query), [
+        {
+          'double': 'foo',
+          'single': 'bar',
+        }
+      ]);
+    });
+
+    test('disable', () {
+      database.configDoubleQuotedStringLiterals(enable: false);
+
+      expect(
+        () => database.select(query),
+        throwsSqlError(SqlError.SQLITE_ERROR, 1),
+      );
+    });
+  });
 }
 
 /// Aggregate function that counts the length of all string parameters it

--- a/sqlite3/test/common/database.dart
+++ b/sqlite3/test/common/database.dart
@@ -741,7 +741,7 @@ void testDatabase(
     const query = 'SELECT "foo" AS double, \'bar\' AS single';
 
     test('enable', () {
-      database.options.doubleQuotedStringLiterals = true;
+      database.config.doubleQuotedStringLiterals = true;
 
       expect(database.select(query), [
         {
@@ -752,7 +752,7 @@ void testDatabase(
     });
 
     test('disable', () {
-      database.options.doubleQuotedStringLiterals = false;
+      database.config.doubleQuotedStringLiterals = false;
 
       expect(
         () => database.select(query),


### PR DESCRIPTION
This could be a solution for https://github.com/simolus3/sqlite3.dart/issues/171
It exposes the `sqlite_db_config` function that we can use to configure the double quotes for a particular database connection.

I added a test for the setting but docs are missing.
Let me know if the implementation and code organization seems ok to you and I'll complete it with documentation if you want to go forward with this solution.