### PR TITLE
Fix web support docs, add `example/multiplatform`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,7 @@ jobs:
       working-directory: sqlite3
 
     - name: Analyze
-      run: dart analyze --fatal-infos
+      run: dart analyze --fatal-infos lib/ test/
       working-directory: ${{ matrix.package }}
 
   test:

--- a/sqlite3/README.md
+++ b/sqlite3/README.md
@@ -111,12 +111,10 @@ import 'package:sqlite3/common.dart';
 import 'package:sqlite3/wasm.dart';
 
 Future<WasmSqlite3> loadSqlite() async {
-  final fs = await IndexedDbFileSystem.open('my_app');
-
-  return await WasmSqlite3.loadFromUrl(
-      Uri.parse('sqlite.wasm'),
-      environment: SqliteEnvironment(fileSystem: fs),
-  );
+  final sqlite = await WasmSqlite3.loadFromUrl(Uri.parse('sqlite.wasm'));
+  final fileSystem = await IndexedDbFileSystem.open(dbName: 'my_app');
+  sqlite.registerVirtualFileSystem(fileSystem, makeDefault: true);
+  return sqlite;
 }
 ```
 
@@ -126,6 +124,9 @@ in `package:sqlite3/sqlite3.dart`, databases can be opened in similar ways.
 An example for such web folder is in `example/web/` of this repo.
 To view the example, copy a compiled `sqlite3.wasm` file to `web/sqlite3.wasm` in this directory.
 Then, run `dart run build_runner serve example:8080` and  visit `http://localhost:8080/web/` in a browser.
+
+Another `example/multiplatform/` uses common interface to `sqlite3` on web and native platforms.
+To run this example, merge its files into a Flutter app.
 
 ### Sharing code between web and a Dart VM
 

--- a/sqlite3/README.md
+++ b/sqlite3/README.md
@@ -111,7 +111,7 @@ import 'package:sqlite3/common.dart';
 import 'package:sqlite3/wasm.dart';
 
 Future<WasmSqlite3> loadSqlite() async {
-  final sqlite = await WasmSqlite3.loadFromUrl(Uri.parse('sqlite.wasm'));
+  final sqlite = await WasmSqlite3.loadFromUrl(Uri.parse('sqlite3.wasm'));
   final fileSystem = await IndexedDbFileSystem.open(dbName: 'my_app');
   sqlite.registerVirtualFileSystem(fileSystem, makeDefault: true);
   return sqlite;

--- a/sqlite3/example/multiplatform/analysis_options.yaml
+++ b/sqlite3/example/multiplatform/analysis_options.yaml
@@ -1,0 +1,2 @@
+# https://dart.dev/guides/language/analysis-options
+include: package:lints/recommended.yaml

--- a/sqlite3/example/multiplatform/db/db.dart
+++ b/sqlite3/example/multiplatform/db/db.dart
@@ -1,0 +1,22 @@
+import 'package:sqlite3/common.dart' show CommonDatabase;
+import 'sqlite3/sqlite3.dart' show openSqliteDb;
+
+late CommonDatabase sqliteDb;
+
+Future<void> openDb() async {
+  sqliteDb = await openSqliteDb();
+
+  final dbVersion =
+      sqliteDb.select('PRAGMA user_version').first['user_version'];
+
+  print('DB version: $dbVersion');
+
+  if (dbVersion == 0) {
+    sqliteDb.execute('''
+      BEGIN;
+      -- TODO
+      PRAGMA user_version = 1;
+      COMMIT;
+    ''');
+  }
+}

--- a/sqlite3/example/multiplatform/db/sqlite3/native.dart
+++ b/sqlite3/example/multiplatform/db/sqlite3/native.dart
@@ -1,0 +1,11 @@
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart'
+    show getApplicationDocumentsDirectory;
+import 'package:sqlite3/common.dart' show CommonDatabase;
+import 'package:sqlite3/sqlite3.dart' show sqlite3;
+
+Future<CommonDatabase> openSqliteDb() async {
+  final docsDir = await getApplicationDocumentsDirectory();
+  final filename = path.join(docsDir.path, 'my_app.db');
+  return sqlite3.open(filename);
+}

--- a/sqlite3/example/multiplatform/db/sqlite3/sqlite3.dart
+++ b/sqlite3/example/multiplatform/db/sqlite3/sqlite3.dart
@@ -1,0 +1,3 @@
+export 'unsupported.dart'
+    if (dart.library.js) 'web.dart'
+    if (dart.library.ffi) 'native.dart' show openSqliteDb;

--- a/sqlite3/example/multiplatform/db/sqlite3/unsupported.dart
+++ b/sqlite3/example/multiplatform/db/sqlite3/unsupported.dart
@@ -1,0 +1,5 @@
+import 'package:sqlite3/common.dart' show CommonDatabase;
+
+Future<CommonDatabase> openSqliteDb() async {
+  throw UnsupportedError('Sqlite3 is unsupported on this platform.');
+}

--- a/sqlite3/example/multiplatform/db/sqlite3/web.dart
+++ b/sqlite3/example/multiplatform/db/sqlite3/web.dart
@@ -3,6 +3,8 @@ import 'package:sqlite3/wasm.dart' show IndexedDbFileSystem, WasmSqlite3;
 
 Future<CommonDatabase> openSqliteDb() async {
   const name = 'my_app';
+  // Please download `sqlite3.wasm` from https://github.com/simolus3/sqlite3.dart/releases
+  // into the `web/` dir of your Flutter app. See `README.md` for details.
   final sqlite = await WasmSqlite3.loadFromUrl(Uri.parse('sqlite3.wasm'));
   final fileSystem = await IndexedDbFileSystem.open(dbName: name);
   sqlite.registerVirtualFileSystem(fileSystem, makeDefault: true);

--- a/sqlite3/example/multiplatform/db/sqlite3/web.dart
+++ b/sqlite3/example/multiplatform/db/sqlite3/web.dart
@@ -1,0 +1,10 @@
+import 'package:sqlite3/common.dart' show CommonDatabase;
+import 'package:sqlite3/wasm.dart' show IndexedDbFileSystem, WasmSqlite3;
+
+Future<CommonDatabase> openSqliteDb() async {
+  const name = 'my_app';
+  final sqlite = await WasmSqlite3.loadFromUrl(Uri.parse('sqlite3.wasm'));
+  final fileSystem = await IndexedDbFileSystem.open(dbName: name);
+  sqlite.registerVirtualFileSystem(fileSystem, makeDefault: true);
+  return sqlite.open(name);
+}

--- a/sqlite3/example/multiplatform/main.dart
+++ b/sqlite3/example/multiplatform/main.dart
@@ -1,0 +1,7 @@
+import 'db/db.dart' show openDb;
+
+Future<void> main() async {
+  // WidgetsFlutterBinding.ensureInitialized();
+  await openDb();
+  // runApp(const App());
+}

--- a/sqlite3/example/multiplatform/pubspec.yaml
+++ b/sqlite3/example/multiplatform/pubspec.yaml
@@ -1,0 +1,16 @@
+name: sqlite3_multiplatform_example
+description: Uses common interface to `sqlite3` on web and native platforms.
+version: 0.1.0
+publish_to: 'none'
+
+environment:
+  sdk: ">=2.12.0 <4.0.0"
+
+dependencies:
+  path: ^1.8.3
+  path_provider: ^2.1.1
+  sqlite3: ^2.1.0
+  # sqlite3_flutter_libs: ^0.5.17
+
+dev_dependencies:
+  lints: ^3.0.0

--- a/sqlite3/example/multiplatform/pubspec.yaml
+++ b/sqlite3/example/multiplatform/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   path: ^1.8.3
-  path_provider: ^2.1.1
+  # path_provider: ^2.1.1
   sqlite3: ^2.1.0
   # sqlite3_flutter_libs: ^0.5.17
 

--- a/sqlite3/pubspec.yaml
+++ b/sqlite3/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   js: ^0.6.4
   meta: ^1.3.0
   path: ^1.8.0
+  path_provider: ^2.1.1
 
 dev_dependencies:
   build_daemon: ^4.0.0

--- a/sqlite3/pubspec.yaml
+++ b/sqlite3/pubspec.yaml
@@ -27,7 +27,6 @@ dependencies:
   js: ^0.6.4
   meta: ^1.3.0
   path: ^1.8.0
-  path_provider: ^2.1.1
 
 dev_dependencies:
   build_daemon: ^4.0.0


### PR DESCRIPTION
* Fixed "WASM (web support)" section of `README`:
  * Replaced `SqliteEnvironment` (which is gone from the codebase) with `registerVirtualFileSystem`.
  * Fixed [IndexedDbFileSystem.open](https://pub.dev/documentation/sqlite3/latest/sqlite3.wasm/IndexedDbFileSystem/open.html) call which requires named argument `dbName` instead of positional one.
* Added `example/multiplatform` which uses common interface to `sqlite3` on web and native platforms.
  * To run this example, merge its files into a Flutter app.
