### PR TITLE
Faster backups

### DIFF
--- a/sqlite3/lib/src/ffi/api.dart
+++ b/sqlite3/lib/src/ffi/api.dart
@@ -120,11 +120,12 @@ abstract class Database extends CommonDatabase {
   /// To simply await the backup operation as a future, call [Stream.drain] on
   /// the returned stream.
   ///
-  /// [nPage] is the number of pages backed-up before releasing locks.  A
-  /// larger value increase speed of backup, but will cause longer read and write
-  /// locks on the source/destination databases.
-  /// See https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupstep for details
-  ///
+  /// [nPage] is the number of pages backed-up in each backup step.
+  /// A larger value increase speed of backup, but will cause other connections to wait
+  /// longer to aquire locks on the source and destination databases.  A value of -1
+  /// can be used to backup the entire database in a single step.
+  /// See https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupstep for details.
+  /// 
   /// See https://www.sqlite.org/c3ref/backup_finish.html
   Stream<double> backup(Database toDatabase, {int nPage = 5});
 }

--- a/sqlite3/lib/src/ffi/api.dart
+++ b/sqlite3/lib/src/ffi/api.dart
@@ -120,8 +120,13 @@ abstract class Database extends CommonDatabase {
   /// To simply await the backup operation as a future, call [Stream.drain] on
   /// the returned stream.
   ///
+  /// [nPage] is the number of pages backed-up before releasing locks.  A
+  /// larger value increase speed of backup, but will cause longer read and write
+  /// locks on the source/destination databases.
+  /// See https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupstep for details
+  ///
   /// See https://www.sqlite.org/c3ref/backup_finish.html
-  Stream<double> backup(Database toDatabase);
+  Stream<double> backup(Database toDatabase, {int nPage = 5});
 }
 
 /// A prepared statement.

--- a/sqlite3/lib/src/ffi/implementation.dart
+++ b/sqlite3/lib/src/ffi/implementation.dart
@@ -93,12 +93,12 @@ final class FfiDatabaseImplementation extends DatabaseImplementation
   }
 
   @override
-  Stream<double> backup(Database toDatabase) {
+  Stream<double> backup(Database toDatabase, {int nPage = 5}) {
     if (isInMemory) {
       _loadOrSaveInMemoryDatabase(toDatabase, true);
       return const Stream.empty();
     } else {
-      return _backupDatabase(toDatabase);
+      return _backupDatabase(toDatabase, nPage);
     }
   }
 
@@ -165,7 +165,7 @@ final class FfiDatabaseImplementation extends DatabaseImplementation
   }
 
   /// Ported from https://www.sqlite.org/backup.html Example 2
-  Stream<double> _backupDatabase(Database toDatabase) async* {
+  Stream<double> _backupDatabase(Database toDatabase, int nPage) async* {
     final zDestDb = Utf8Utils.allocateZeroTerminated('main');
     final zSrcDb = Utf8Utils.allocateZeroTerminated('main');
 
@@ -175,7 +175,7 @@ final class FfiDatabaseImplementation extends DatabaseImplementation
     int returnCode;
     if (!pBackup.isNullPointer) {
       do {
-        returnCode = _bindings.sqlite3_backup_step(pBackup, 5);
+        returnCode = _bindings.sqlite3_backup_step(pBackup, nPage);
 
         final remaining = _bindings.sqlite3_backup_remaining(pBackup);
         final count = _bindings.sqlite3_backup_pagecount(pBackup);

--- a/sqlite3/test/ffi/database_test.dart
+++ b/sqlite3/test/ffi/database_test.dart
@@ -107,66 +107,7 @@ void main() {
       db2.dispose();
     });
 
-    test('backup memory to disk', () async {
-      final db1 = sqlite3.openInMemory();
-      db1.execute('CREATE TABLE a(b INTEGER);');
-      db1.execute('INSERT INTO a VALUES (1);');
-
-      final db2 = sqlite3.open(path);
-
-      final progressStream = db1.backup(db2);
-      await expectLater(progressStream, emitsDone);
-
-      //Should not be included in backup
-      db1.execute('INSERT INTO a VALUES (2);');
-
-      db1.dispose();
-      db2.dispose();
-
-      final db3 = sqlite3.open(path);
-
-      expect(db3.select('SELECT * FROM a'), hasLength(1));
-
-      db3.dispose();
-    });
-
-    test('backup disk to disk', () async {
-      final pathFrom = d.path('test_from.db');
-      Directory(dirname(pathFrom)).createSync(recursive: true);
-
-      if (File(pathFrom).existsSync()) {
-        File(pathFrom).deleteSync();
-      }
-
-      final db1 = sqlite3.open(pathFrom);
-
-      db1.execute('CREATE TABLE a(b INTEGER);');
-      db1.execute('INSERT INTO a VALUES (1);');
-
-      final db2 = sqlite3.open(path);
-
-      final progressStream = db1.backup(db2);
-      await expectLater(
-          progressStream, emitsInOrder(<Matcher>[emitsThrough(1), emitsDone]));
-
-      //Should not be included in backup
-      db1.execute('INSERT INTO a VALUES (2);');
-
-      db1.dispose();
-      db2.dispose();
-
-      final db3 = sqlite3.open(path);
-
-      expect(db3.select('SELECT * FROM a'), hasLength(1));
-
-      db3.dispose();
-
-      if (File(pathFrom).existsSync()) {
-        File(pathFrom).deleteSync();
-      }
-    });
-
-    group('backup disk to disk w/ custom nPage', () {
+    group('backup disk to disk', () {
       var inputs = [-1, 1, 5, 1024];
       for (var nPage in inputs) {
         test('nPage = $nPage', () async {
@@ -207,7 +148,7 @@ void main() {
       }
     });
 
-    group('backup memory to disk w/ custom nPage', () {
+    group('backup memory to disk', () {
       var inputs = [-1, 1, 5, 1024];
 
       for (var nPage in inputs) {

--- a/sqlite3/test/ffi/database_test.dart
+++ b/sqlite3/test/ffi/database_test.dart
@@ -165,5 +165,75 @@ void main() {
         File(pathFrom).deleteSync();
       }
     });
+
+    group('backup disk to disk w/ custom nPage', () {
+      var inputs = [-1, 1, 5, 1024];
+      for (var nPage in inputs) {
+        test('nPage = $nPage', () async {
+          final pathFrom = d.path('test_from.db');
+          Directory(dirname(pathFrom)).createSync(recursive: true);
+
+          if (File(pathFrom).existsSync()) {
+            File(pathFrom).deleteSync();
+          }
+
+          final db1 = sqlite3.open(pathFrom);
+
+          db1.execute('CREATE TABLE a(b INTEGER);');
+          db1.execute('INSERT INTO a VALUES (1);');
+
+          final db2 = sqlite3.open(path);
+
+          final progressStream = db1.backup(db2, nPage: nPage);
+          await expectLater(progressStream,
+              emitsInOrder(<Matcher>[emitsThrough(1), emitsDone]));
+
+          //Should not be included in backup
+          db1.execute('INSERT INTO a VALUES (2);');
+
+          db1.dispose();
+          db2.dispose();
+
+          final db3 = sqlite3.open(path);
+
+          expect(db3.select('SELECT * FROM a'), hasLength(1));
+
+          db3.dispose();
+
+          if (File(pathFrom).existsSync()) {
+            File(pathFrom).deleteSync();
+          }
+        });
+      }
+    });
+
+    group('backup memory to disk w/ custom nPage', () {
+      var inputs = [-1, 1, 5, 1024];
+
+      for (var nPage in inputs) {
+        test('nPage = $nPage', () async {
+          final db1 = sqlite3.openInMemory();
+          db1.execute('CREATE TABLE a(b INTEGER);');
+          db1.execute('INSERT INTO a VALUES (1);');
+
+          final db2 = sqlite3.open(path);
+
+          final progressStream = db1.backup(db2, nPage: nPage);
+          await expectLater(progressStream, emitsDone);
+
+          //Should not be included in backup
+          db1.execute('INSERT INTO a VALUES (2);');
+
+          db1.dispose();
+          db2.dispose();
+
+          final db3 = sqlite3.open(path);
+
+          expect(db3.select('SELECT * FROM a'), hasLength(1));
+
+          db3.dispose();
+        });
+      }
+    });
   });
 }


### PR DESCRIPTION
### Rationale
Backup performance is very slow when calling `Database.backup()`

### Cause
The library has a hardcoded value of N=5 in the call to [sqlite3_backup_step](https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupstep).  This parameter specifies how many pages of data get saved in each step.  See SQLite docs for details.

In a performance test changing N from 5 to 1024 reduced the time to complete a backup of a 21MB database
from 8 minutes to 620ms.

### API Changes:
An optional `nPages` parameter was added to allow one to configure how many blocks to backup 
in each call to [sqlite3_backup_step](https://www.sqlite.org/c3ref/backup_finish.html#sqlite3backupstep). This is fully backwards compatible as the parameter is optional.

```Dart
/// Old API
Stream<double> backup(Database toDatabase);

// New API
Stream<double> backup(Database toDatabase, {int nPage = 5});
```


