### PR TITLE
Expose sqlite3_get_autocommit

### DIFF
--- a/sqlite3/assets/sqlite3.h
+++ b/sqlite3/assets/sqlite3.h
@@ -35,6 +35,7 @@ void *sqlite3_update_hook(sqlite3 *,
                           void (*)(void *, int, sqlite3_char const *,
                                    sqlite3_char const *, int64_t),
                           void *);
+int sqlite3_get_autocommit(sqlite3 *db);
 
 // Statements
 int sqlite3_prepare_v2(sqlite3 *db, const sqlite3_char *zSql, int nByte,

--- a/sqlite3/lib/src/database.dart
+++ b/sqlite3/lib/src/database.dart
@@ -178,6 +178,12 @@ abstract class CommonDatabase {
     bool directOnly = true,
   });
 
+  /// Checks whether the connection is in autocommit mode. The connection is in
+  /// autocommit by default, except when inside a transaction.
+  ///
+  /// For details, see https://www.sqlite.org/c3ref/get_autocommit.html
+  bool getAutocommit();
+
   /// Closes this database and releases associated resources.
   void dispose();
 }

--- a/sqlite3/lib/src/database.dart
+++ b/sqlite3/lib/src/database.dart
@@ -182,7 +182,7 @@ abstract class CommonDatabase {
   /// autocommit by default, except when inside a transaction.
   ///
   /// For details, see https://www.sqlite.org/c3ref/get_autocommit.html
-  bool getAutocommit();
+  bool get autocommit;
 
   /// Closes this database and releases associated resources.
   void dispose();

--- a/sqlite3/lib/src/ffi/bindings.dart
+++ b/sqlite3/lib/src/ffi/bindings.dart
@@ -286,6 +286,11 @@ final class FfiDatabase extends RawSqliteDatabase {
   }
 
   @override
+  int sqlite3_get_autocommit() {
+    return bindings.bindings.sqlite3_get_autocommit(db);
+  }
+
+  @override
   RawStatementCompiler newCompiler(List<int> utf8EncodedSql) {
     return FfiStatementCompiler(this, allocateBytes(utf8EncodedSql));
   }

--- a/sqlite3/lib/src/ffi/sqlite3.g.dart
+++ b/sqlite3/lib/src/ffi/sqlite3.g.dart
@@ -308,6 +308,20 @@ class Bindings {
                       ffi.Int64)>>,
           ffi.Pointer<ffi.Void>)>();
 
+  int sqlite3_get_autocommit(
+    ffi.Pointer<sqlite3> db,
+  ) {
+    return _sqlite3_get_autocommit(
+      db,
+    );
+  }
+
+  late final _sqlite3_get_autocommitPtr =
+      _lookup<ffi.NativeFunction<ffi.Int Function(ffi.Pointer<sqlite3>)>>(
+          'sqlite3_get_autocommit');
+  late final _sqlite3_get_autocommit = _sqlite3_get_autocommitPtr
+      .asFunction<int Function(ffi.Pointer<sqlite3>)>();
+
   int sqlite3_prepare_v2(
     ffi.Pointer<sqlite3> db,
     ffi.Pointer<sqlite3_char> zSql,

--- a/sqlite3/lib/src/implementation/bindings.dart
+++ b/sqlite3/lib/src/implementation/bindings.dart
@@ -105,6 +105,7 @@ abstract base class RawSqliteDatabase {
   });
 
   int sqlite3_db_config(int op, int value);
+  int sqlite3_get_autocommit();
 }
 
 /// A stateful wrapper around multiple `sqlite3_prepare` invocations.

--- a/sqlite3/lib/src/implementation/database.dart
+++ b/sqlite3/lib/src/implementation/database.dart
@@ -269,7 +269,7 @@ base class DatabaseImplementation implements CommonDatabase {
   int get lastInsertRowId => database.sqlite3_last_insert_rowid();
 
   @override
-  bool getAutocommit() {
+  bool get autocommit {
     return database.sqlite3_get_autocommit() != 0;
   }
 

--- a/sqlite3/lib/src/implementation/database.dart
+++ b/sqlite3/lib/src/implementation/database.dart
@@ -268,6 +268,11 @@ base class DatabaseImplementation implements CommonDatabase {
   @override
   int get lastInsertRowId => database.sqlite3_last_insert_rowid();
 
+  @override
+  bool getAutocommit() {
+    return database.sqlite3_get_autocommit() != 0;
+  }
+
   List<StatementImplementation> _prepareInternal(String sql,
       {bool persistent = false,
       bool vtab = true,

--- a/sqlite3/lib/src/wasm/bindings.dart
+++ b/sqlite3/lib/src/wasm/bindings.dart
@@ -247,6 +247,11 @@ final class WasmDatabase extends RawSqliteDatabase {
   }
 
   @override
+  int sqlite3_get_autocommit() {
+    return bindings.sqlite3_get_autocommit(db);
+  }
+
+  @override
   int sqlite3_db_config(int op, int value) {
     return bindings.sqlite3_db_config(db, op, value);
   }

--- a/sqlite3/lib/src/wasm/wasm_interop.dart
+++ b/sqlite3/lib/src/wasm/wasm_interop.dart
@@ -77,7 +77,8 @@ class WasmBindings {
       _sqlite3_value_bytes,
       _sqlite3_value_text,
       _sqlite3_value_blob,
-      _sqlite3_aggregate_context;
+      _sqlite3_aggregate_context,
+      _sqlite3_get_autocommit;
 
   final Function? _sqlite3_db_config;
 
@@ -152,6 +153,7 @@ class WasmBindings {
         _sqlite3_value_blob = instance.functions['sqlite3_value_blob']!,
         _sqlite3_aggregate_context =
             instance.functions['sqlite3_aggregate_context']!,
+        _sqlite3_get_autocommit = instance.functions['sqlite3_get_autocommit']!,
         _sqlite3_db_config = instance.functions['dart_sqlite3_db_config_int'],
         _sqlite3_temp_directory = instance.globals['sqlite3_temp_directory']! {
     values.bindings = this;
@@ -404,6 +406,8 @@ class WasmBindings {
 
   int sqlite3_last_insert_rowid(Pointer db) =>
       JsBigInt(_sqlite3_last_insert_rowid(db) as Object).asDartInt;
+
+  int sqlite3_get_autocommit(Pointer db) => _sqlite3_get_autocommit(db) as int;
 
   int sqlite3_db_config(Pointer db, int op, int value) {
     final function = _sqlite3_db_config;

--- a/sqlite3/test/common/database.dart
+++ b/sqlite3/test/common/database.dart
@@ -763,12 +763,12 @@ void testDatabase(
     });
   });
 
-  test('getAutocommit', () {
-    expect(database.getAutocommit(), equals(true));
+  test('autocommit', () {
+    expect(database.autocommit, equals(true));
     database.execute('BEGIN');
-    expect(database.getAutocommit(), equals(false));
+    expect(database.autocommit, equals(false));
     database.execute('ROLLBACK');
-    expect(database.getAutocommit(), equals(true));
+    expect(database.autocommit, equals(true));
   });
 }
 

--- a/sqlite3/test/common/database.dart
+++ b/sqlite3/test/common/database.dart
@@ -762,6 +762,14 @@ void testDatabase(
       );
     });
   });
+
+  test('getAutocommit', () {
+    expect(database.getAutocommit(), equals(true));
+    database.execute('BEGIN');
+    expect(database.getAutocommit(), equals(false));
+    database.execute('ROLLBACK');
+    expect(database.getAutocommit(), equals(true));
+  });
 }
 
 /// Aggregate function that counts the length of all string parameters it


### PR DESCRIPTION
Expose [sqlite3_get_autocommit](https://www.sqlite.org/c3ref/get_autocommit.html) to check whether or not the connection is currently within a transaction.

For the use case, see https://github.com/powersync-ja/sqlite_async.dart/issues/21.

Note: I added an implementation for both ffi and wasm, but I haven't tested the wasm version (couldn't quickly see how to run the tests).