### PR TITLE
Bump js dependency to ^0.7.0

### DIFF
--- a/sqlite3/pubspec.yaml
+++ b/sqlite3/pubspec.yaml
@@ -24,7 +24,7 @@ topics:
 dependencies:
   collection: ^1.15.0
   ffi: '>=1.2.1 <3.0.0'
-  js: ^0.7.0
+  js: '>=0.6.4 <0.8.0'
   meta: ^1.3.0
   path: ^1.8.0
 

--- a/sqlite3/pubspec.yaml
+++ b/sqlite3/pubspec.yaml
@@ -24,7 +24,7 @@ topics:
 dependencies:
   collection: ^1.15.0
   ffi: '>=1.2.1 <3.0.0'
-  js: ^0.6.4
+  js: ^0.7.0
   meta: ^1.3.0
   path: ^1.8.0
 


### PR DESCRIPTION
This resolves the "Support up-to-date dependencies" scoring issue on pub.dev for this package and others that depend on it. Tests still pass on my machine for native and wasm.

Update: I see the issues with js `^0.7.0` and integration_test now, `>=0.6.4 <0.8.0` should work to still support that.