### PR TITLE
Better wasm support

### DIFF
--- a/sqlite3/lib/common.dart
+++ b/sqlite3/lib/common.dart
@@ -10,4 +10,3 @@ export 'src/result_set.dart';
 export 'src/sqlite3.dart';
 export 'src/statement.dart'
     show CommonPreparedStatement, StatementParameters, CustomStatementParameter;
-export 'src/vfs.dart';

--- a/sqlite3/lib/src/wasm/js_interop.dart
+++ b/sqlite3/lib/src/wasm/js_interop.dart
@@ -1,7 +1,7 @@
 import 'dart:js_interop';
-import 'dart:typed_data';
 
 import 'package:web/web.dart' show Blob;
+import 'js_interop/typed_data.dart';
 
 // This internal library exports wrappers around newer Web APIs for which no
 // up-to-date bindings exist in the Dart SDK.
@@ -15,8 +15,8 @@ export 'js_interop/typed_data.dart';
 export 'js_interop/wasm.dart';
 
 extension ReadBlob on Blob {
-  Future<ByteBuffer> byteBuffer() async {
+  Future<SafeBuffer> byteBuffer() async {
     final buffer = await arrayBuffer().toDart;
-    return buffer.toDart;
+    return SafeBuffer(buffer);
   }
 }

--- a/sqlite3/lib/src/wasm/js_interop/atomics.dart
+++ b/sqlite3/lib/src/wasm/js_interop/atomics.dart
@@ -1,6 +1,7 @@
-import 'dart:typed_data';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
+
+import 'typed_data.dart';
 
 @JS('Int32Array')
 external JSFunction _int32Array;
@@ -17,24 +18,22 @@ extension type SharedArrayBuffer._(JSObject _) implements JSObject {
 
   external int get byteLength;
 
-  Int32List asInt32List() {
-    return _int32Array.callAsConstructor<JSInt32Array>(this).toDart;
+  SafeI32Array asInt32List() {
+    return SafeI32Array(_int32Array.callAsConstructor<JSInt32Array>(this));
   }
 
-  ByteData asByteData(int offset, int length) {
-    return _dataView
-        .callAsConstructor<JSDataView>(this, offset.toJS, length.toJS)
-        .toDart;
+  SafeDataView asByteData(int offset, int length) {
+    return SafeDataView(_dataView.callAsConstructor<JSDataView>(
+        this, offset.toJS, length.toJS));
   }
 
-  Uint8List asUint8List() {
-    return _uint8Array.callAsConstructor<JSUint8Array>(this).toDart;
+  SafeU8Array asUint8List() {
+    return SafeU8Array(_uint8Array.callAsConstructor<JSUint8Array>(this));
   }
 
-  Uint8List asUint8ListSlice(int offset, int length) {
-    return _uint8Array
-        .callAsConstructor<JSUint8Array>(this, offset.toJS, length.toJS)
-        .toDart;
+  SafeU8Array asUint8ListSlice(int offset, int length) {
+    return SafeU8Array(_uint8Array.callAsConstructor<JSUint8Array>(
+        this, offset.toJS, length.toJS));
   }
 }
 
@@ -66,27 +65,27 @@ class Atomics {
     return globalContext.has('Atomics');
   }
 
-  static String wait(Int32List typedArray, int index, int value) {
-    return _Atomics.wait(typedArray.toJS, index, value).toDart;
+  static String wait(SafeI32Array typedArray, int index, int value) {
+    return _Atomics.wait(typedArray.inner, index, value).toDart;
   }
 
   static String waitWithTimeout(
-      Int32List typedArray, int index, int value, int timeOutInMillis) {
+      SafeI32Array typedArray, int index, int value, int timeOutInMillis) {
     return _Atomics.waitWithTimeout(
-            typedArray.toJS, index, value, timeOutInMillis)
+            typedArray.inner, index, value, timeOutInMillis)
         .toDart;
   }
 
-  static void notify(Int32List typedArray, int index,
+  static void notify(SafeI32Array typedArray, int index,
       [num count = double.infinity]) {
-    _Atomics.notify(typedArray.toJS, index, count);
+    _Atomics.notify(typedArray.inner, index, count);
   }
 
-  static int store(Int32List typedArray, int index, int value) {
-    return _Atomics.store(typedArray.toJS, index, value);
+  static int store(SafeI32Array typedArray, int index, int value) {
+    return _Atomics.store(typedArray.inner, index, value);
   }
 
-  static int load(Int32List typedArray, int index) {
-    return _Atomics.load(typedArray.toJS, index);
+  static int load(SafeI32Array typedArray, int index) {
+    return _Atomics.load(typedArray.inner, index);
   }
 }

--- a/sqlite3/lib/src/wasm/js_interop/new_file_system_access.dart
+++ b/sqlite3/lib/src/wasm/js_interop/new_file_system_access.dart
@@ -1,10 +1,10 @@
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
-import 'dart:typed_data';
 
 import 'package:web/web.dart';
 
 import 'core.dart';
+import 'typed_data.dart';
 
 @JS('navigator')
 external Navigator get _navigator;
@@ -24,19 +24,19 @@ extension StorageManagerApi on StorageManager {
 }
 
 extension FileSystemSyncAccessHandleApi on FileSystemSyncAccessHandle {
-  int readDart(Uint8List buffer, [FileSystemReadWriteOptions? options]) {
+  int readDart(SafeU8Array buffer, [FileSystemReadWriteOptions? options]) {
     if (options == null) {
-      return read(buffer.toJS);
+      return read(buffer);
     } else {
-      return read(buffer.toJS, options);
+      return read(buffer, options);
     }
   }
 
-  int writeDart(Uint8List buffer, [FileSystemReadWriteOptions? options]) {
+  int writeDart(SafeU8Array buffer, [FileSystemReadWriteOptions? options]) {
     if (options == null) {
-      return write(buffer.toJS);
+      return write(buffer);
     } else {
-      return write(buffer.toJS, options);
+      return write(buffer, options);
     }
   }
 }

--- a/sqlite3/lib/src/wasm/js_interop/typed_data.dart
+++ b/sqlite3/lib/src/wasm/js_interop/typed_data.dart
@@ -1,21 +1,62 @@
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
-import 'dart:typed_data';
 
 import 'core.dart';
 
-extension NativeUint8List on Uint8List {
-  /// A native version of [setRange] that takes another typed array directly.
-  /// This avoids the type checks part of [setRange] in compiled JavaScript
-  /// code.
-  void set(Uint8List from, int offset) {
-    toJS.callMethod('set'.toJS, from.toJS, offset.toJS);
+// These types provide wrappers around JS typeddata objects that don't have
+// the toDart extension on them.
+// Using toDart is unsafe as it creates a reference in dart2js while copying in
+// dart2wasm. This causes issues that are very hard to find, so we should be
+// very explicit about where we copy and explain why that's safe.
+
+extension type SafeBuffer(JSArrayBuffer inner) implements JSObject {}
+
+extension type SafeDataView(JSDataView inner) implements JSObject {
+  @JS('')
+  external factory SafeDataView.entireBufferView(SafeBuffer buffer);
+
+  external void setInt32(int byteOffset, int value);
+  external int getInt32(int byteOffset);
+
+  external void setBigInt64(int offset, JsBigInt value, bool littleEndian);
+}
+
+extension type SafeU8Array(JSUint8Array inner) implements JSObject {
+  @JS('')
+  external factory SafeU8Array.allocate(int length);
+
+  @JS('')
+  external factory SafeU8Array.entireBufferView(SafeBuffer buffer);
+
+  @JS('')
+  external factory SafeU8Array.bufferView(
+      SafeBuffer buffer, int byteOffset, int length);
+
+  external void set(JSTypedArray array, int targetOffset);
+  external void fill(int value, int start, int end);
+
+  external SafeU8Array subarray(int begin, int end);
+
+  external int get length;
+
+  int operator [](int index) {
+    return getProperty<JSNumber>(index.toJS).toDartInt;
+  }
+
+  void operator []=(int index, int value) {
+    setProperty(index.toJS, value.toJS);
   }
 }
 
-extension NativeDataView on ByteData {
-  void setBigInt64(int offset, JsBigInt value, bool littleEndian) {
-    toJS.callMethod(
-        'setBigInt64'.toJS, offset.toJS, value.jsObject, littleEndian.toJS);
+extension type SafeI32Array(JSInt32Array inner) implements JSObject {
+  @JS('')
+  external factory SafeI32Array.entireBufferView(SafeBuffer buffer);
+
+  int operator [](int index) {
+    return getProperty<JSNumber>(index.toJS).toDartInt;
+  }
+
+  void operator []=(int index, int value) {
+    setProperty(index.toJS, value.toJS);
   }
 }

--- a/sqlite3/lib/src/wasm/js_interop/wasm.dart
+++ b/sqlite3/lib/src/wasm/js_interop/wasm.dart
@@ -5,6 +5,7 @@ import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
 import 'core.dart';
+import 'typed_data.dart';
 
 import 'package:web/web.dart' as web;
 
@@ -71,7 +72,7 @@ extension type MemoryDescriptor._(JSObject _) implements JSObject {
 extension type Memory._(JSObject _) implements JSObject {
   external factory Memory(MemoryDescriptor descriptor);
 
-  external JSArrayBuffer get buffer;
+  external SafeBuffer get buffer;
 }
 
 @JS('WebAssembly.Global')

--- a/sqlite3/lib/src/wasm/sqlite3.dart
+++ b/sqlite3/lib/src/wasm/sqlite3.dart
@@ -5,7 +5,7 @@ import 'dart:typed_data';
 import 'package:web/web.dart' as web;
 
 import '../implementation/sqlite3.dart';
-import '../vfs.dart';
+import 'vfs.dart';
 import 'bindings.dart';
 import 'js_interop.dart';
 import 'wasm_interop.dart';

--- a/sqlite3/lib/src/wasm/vfs.dart
+++ b/sqlite3/lib/src/wasm/vfs.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
-import 'dart:typed_data';
 
-import 'constants.dart';
+import '../constants.dart';
+import 'js_interop/typed_data.dart';
 
 /// An exception thrown by [VirtualFileSystem] implementations written in Dart
 /// to signal that an operation could not be completed.
@@ -68,7 +68,7 @@ abstract base class VirtualFileSystem {
   ///
   /// __Safety warning__: Target may be a direct view over native memory that
   /// must not be used after this function returns.
-  void xRandomness(Uint8List target);
+  void xRandomness(SafeU8Array target);
 
   /// Sleeps for the passed [duration].
   void xSleep(Duration duration);
@@ -95,7 +95,7 @@ abstract interface class VirtualFileSystemFile {
   ///
   /// __Safety warning__: Target may be a direct view over native memory that
   /// must not be used after this function returns.
-  void xRead(Uint8List target, int fileOffset);
+  void xRead(SafeU8Array target, int fileOffset);
 
   /// Writes the [buffer] into this file at [fileOffset], overwriting existing
   /// content or appending to it.
@@ -105,7 +105,7 @@ abstract interface class VirtualFileSystemFile {
   ///
   /// __Safety warning__: Target may be a direct view over native memory that
   /// must not be used after this function returns.
-  void xWrite(Uint8List buffer, int fileOffset);
+  void xWrite(SafeU8Array buffer, int fileOffset);
 
   /// Truncates this file to a size of [size].
   void xTruncate(int size);
@@ -139,7 +139,7 @@ abstract base class BaseVirtualFileSystem extends VirtualFileSystem {
         super(name);
 
   @override
-  void xRandomness(Uint8List target) {
+  void xRandomness(SafeU8Array target) {
     for (var i = 0; i < target.length; i++) {
       target[i] = random.nextInt(1 << 8);
     }
@@ -157,18 +157,18 @@ abstract class BaseVfsFile implements VirtualFileSystemFile {
   ///
   /// __Safety warning__: [bufer] may be a direct view over native memory that
   /// must not be used after this function returns.
-  int readInto(Uint8List buffer, int offset);
+  int readInto(SafeU8Array buffer, int offset);
 
   @override
   int get xDeviceCharacteristics => 0;
 
   @override
-  void xRead(Uint8List target, int fileOffset) {
+  void xRead(SafeU8Array target, int fileOffset) {
     final bytesRead = readInto(target, fileOffset);
 
     if (bytesRead < target.length) {
       // Remaining buffer must be filled with zeroes.
-      target.fillRange(bytesRead, target.length, 0);
+      target.fill(0, bytesRead, target.length);
 
       // And we need to return a short read error
       throw const VfsException(SqlExtendedError.SQLITE_IOERR_SHORT_READ);

--- a/sqlite3/lib/src/wasm/vfs/async_opfs/worker.dart
+++ b/sqlite3/lib/src/wasm/vfs/async_opfs/worker.dart
@@ -13,7 +13,7 @@ import 'package:web/web.dart'
         FileSystemReadWriteOptions;
 
 import '../../../constants.dart';
-import '../../../vfs.dart';
+import '../../vfs.dart';
 import '../../js_interop.dart';
 import 'sync_channel.dart';
 
@@ -175,7 +175,7 @@ class VfsWorker {
 
     final syncHandle = await _openForSynchronousAccess(file);
     final bytesRead = syncHandle.readDart(
-        messages.viewByteRange(0, bufferLength),
+        messages.byteView.subarray(0, bufferLength),
         FileSystemReadWriteOptions(at: offset));
 
     return Flags(bytesRead, 0, 0);
@@ -189,7 +189,7 @@ class VfsWorker {
 
     final syncHandle = await _openForSynchronousAccess(file);
     final bytesWritten = syncHandle.writeDart(
-        messages.viewByteRange(0, bufferLength),
+        messages.byteView.subarray(0, bufferLength),
         FileSystemReadWriteOptions(at: offset));
 
     if (bytesWritten != bufferLength) {

--- a/sqlite3/lib/src/wasm/vfs/indexed_db.dart
+++ b/sqlite3/lib/src/wasm/vfs/indexed_db.dart
@@ -5,13 +5,12 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:js_interop';
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:web/web.dart' as web;
 
 import '../../constants.dart';
-import '../../vfs.dart';
+import '../vfs.dart';
 import '../js_interop.dart';
 import 'memory.dart';
 import 'utils.dart';
@@ -141,12 +140,12 @@ class AsynchronousIndexedDbFileSystem {
     });
   }
 
-  Future<Uint8List> readFully(int fileId) async {
+  Future<SafeU8Array> readFully(int fileId) async {
     final transaction = _database!.transaction(_storesJs, 'readonly');
     final blocks = transaction.objectStore(_blocksStore);
 
     final file = await _readFile(transaction, fileId);
-    final result = Uint8List(file.length);
+    final result = SafeU8Array.allocate(file.length);
 
     final readOperations = <Future<void>>[];
 
@@ -163,7 +162,7 @@ class AsynchronousIndexedDbFileSystem {
       // transaction. Launch the reader now and wait for all reads later.
       readOperations.add(Future.sync(() async {
         final data = await (row.value as web.Blob).byteBuffer();
-        result.setAll(rowOffset, data.asUint8List(0, length));
+        result.set(SafeU8Array.bufferView(data, 0, length).inner, rowOffset);
       }));
     }
     await Future.wait(readOperations);
@@ -171,7 +170,7 @@ class AsynchronousIndexedDbFileSystem {
     return result;
   }
 
-  Future<int> read(int fileId, int offset, Uint8List target) async {
+  Future<int> read(int fileId, int offset, SafeU8Array target) async {
     final transaction = _database!.transaction(_storesJs, 'readonly');
     final blocks = transaction.objectStore(_blocksStore);
 
@@ -204,11 +203,8 @@ class AsynchronousIndexedDbFileSystem {
         readOperations.add(Future.sync(() async {
           final data = await blob.byteBuffer();
 
-          target.setRange(
-            0,
-            lengthToCopy,
-            data.asUint8List(startInRow, lengthToCopy),
-          );
+          target.set(
+              SafeU8Array.bufferView(data, startInRow, lengthToCopy).inner, 0);
         }));
 
         if (lengthToCopy >= target.length) {
@@ -226,7 +222,8 @@ class AsynchronousIndexedDbFileSystem {
         readOperations.add(Future.sync(() async {
           final data = await blob.byteBuffer();
 
-          target.setAll(startInTarget, data.asUint8List(0, lengthToCopy));
+          target.set(SafeU8Array.bufferView(data, 0, lengthToCopy).inner,
+              startInTarget);
         }));
 
         if (lengthToCopy >= target.length - startInTarget) {
@@ -244,14 +241,14 @@ class AsynchronousIndexedDbFileSystem {
     final blocks = transaction.objectStore(_blocksStore);
     final file = await _readFile(transaction, fileId);
 
-    Future<void> writeBlock(int blockStart, Uint8List block) async {
+    Future<void> writeBlock(int blockStart, SafeU8Array block) async {
       assert(block.length == _blockSize, 'Invalid block size');
 
       // Check if we're overriding (parts of) an existing block
       final cursor = await blocks
           .openCursor(web.IDBKeyRange.only([fileId.toJS, blockStart.toJS].toJS))
           .complete<web.IDBCursorWithValue?>();
-      final blob = web.Blob([block.toJS].toJS);
+      final blob = web.Blob([block].toJS);
 
       if (cursor == null) {
         // There isn't, let's write a new block
@@ -333,34 +330,38 @@ extension type _FileEntry._(JSObject _) implements JSObject {
 class _FileWriteRequest {
   static const _blockLength = AsynchronousIndexedDbFileSystem._blockSize;
 
-  final Uint8List originalContent;
-  final Map<int, Uint8List> replacedBlocks = {};
+  final SafeU8Array originalContent;
+  final Map<int, SafeU8Array> replacedBlocks = {};
   int newFileLength;
 
   _FileWriteRequest(this.originalContent)
       : newFileLength = originalContent.length;
 
-  void _updateBlock(int blockOffset, int offsetInBlock, Uint8List data) {
+  void _updateBlock(int blockOffset, int offsetInBlock, SafeU8Array data) {
     final block = replacedBlocks.putIfAbsent(blockOffset, () {
-      final block = Uint8List(_blockLength);
+      final block = SafeU8Array.allocate(_blockLength);
 
       if (originalContent.length > blockOffset) {
-        block.setAll(
+        // We might only be changing parts of a block, so copy the original data
+        // that would have been part of this block.
+        block.set(
+          originalContent
+              .subarray(
+                blockOffset,
+                min(originalContent.length, blockOffset + _blockLength),
+              )
+              .inner,
           0,
-          originalContent.buffer.asUint8List(
-            originalContent.offsetInBytes + blockOffset,
-            min(_blockLength, originalContent.length - blockOffset),
-          ),
         );
       }
 
       return block;
     });
 
-    block.setAll(offsetInBlock, data);
+    block.set(data.inner, offsetInBlock);
   }
 
-  void addWrite(int offset, Uint8List data) {
+  void addWrite(int offset, SafeU8Array data) {
     var offsetInData = 0;
     while (offsetInData < data.length) {
       final offsetInFile = offset + offsetInData;
@@ -379,8 +380,7 @@ class _FileWriteRequest {
         offsetInBlock = 0;
       }
 
-      final chunk = data.buffer
-          .asUint8List(data.offsetInBytes + offsetInData, bytesToWrite);
+      final chunk = data.subarray(offsetInData, offsetInData + bytesToWrite);
       offsetInData += bytesToWrite;
 
       _updateBlock(blockStart, offsetInBlock, chunk);
@@ -392,7 +392,7 @@ class _FileWriteRequest {
 
 class _OffsetAndBuffer {
   final int offset;
-  final Uint8List buffer;
+  final SafeU8Array buffer;
 
   _OffsetAndBuffer(this.offset, this.buffer);
 }
@@ -599,7 +599,7 @@ class _IndexedDbFile implements VirtualFileSystemFile {
   _IndexedDbFile(this.vfs, this.memoryFile, this.path);
 
   @override
-  void xRead(Uint8List target, int fileOffset) {
+  void xRead(SafeU8Array target, int fileOffset) {
     memoryFile.xRead(target, fileOffset);
   }
 
@@ -639,17 +639,18 @@ class _IndexedDbFile implements VirtualFileSystemFile {
   void xUnlock(int mode) => memoryFile.xUnlock(mode);
 
   @override
-  void xWrite(Uint8List buffer, int fileOffset) {
+  void xWrite(SafeU8Array buffer, int fileOffset) {
     vfs._checkClosed();
 
-    final previousContent = vfs._memory.fileData[path] ?? Uint8List(0);
+    final previousContent =
+        vfs._memory.fileData[path] ?? SafeU8Array.allocate(0);
     memoryFile.xWrite(buffer, fileOffset);
 
     if (!vfs._inMemoryOnlyFiles.contains(path)) {
       // We need to copy the buffer for the write because it will become invalid
       // after this synchronous method returns.
-      final copy = Uint8List(buffer.length);
-      copy.setAll(0, buffer);
+      final copy = SafeU8Array.allocate(buffer.length);
+      copy.set(buffer.inner, 0);
 
       vfs._submitWork(_WriteFileWorkItem(vfs, path, previousContent)
         ..writes.add(_OffsetAndBuffer(fileOffset, copy)));
@@ -768,7 +769,7 @@ final class _WriteFileWorkItem extends _IndexedDbWorkItem {
   final IndexedDbFileSystem fileSystem;
   final String path;
 
-  final Uint8List originalContent;
+  final SafeU8Array originalContent;
   final List<_OffsetAndBuffer> writes = [];
 
   _WriteFileWorkItem(this.fileSystem, this.path, this.originalContent);

--- a/sqlite3/lib/src/wasm/vfs/memory.dart
+++ b/sqlite3/lib/src/wasm/vfs/memory.dart
@@ -1,14 +1,14 @@
 import 'dart:math';
-import 'dart:typed_data';
 
 import 'package:path/path.dart' as p;
 
 import '../../constants.dart';
-import '../../vfs.dart';
+import '../js_interop/typed_data.dart';
+import '../vfs.dart';
 import 'utils.dart';
 
 final class InMemoryFileSystem extends BaseVirtualFileSystem {
-  final Map<String, Uint8List?> fileData = {};
+  final Map<String, SafeU8Array?> fileData = {};
 
   InMemoryFileSystem({super.name = 'dart-memory', super.random});
 
@@ -34,7 +34,7 @@ final class InMemoryFileSystem extends BaseVirtualFileSystem {
       final create = flags & SqlFlag.SQLITE_OPEN_CREATE;
 
       if (create != 0) {
-        fileData[pathStr] = Uint8List(0);
+        fileData[pathStr] = SafeU8Array.allocate(0);
       } else {
         throw VfsException(SqlError.SQLITE_CANTOPEN);
       }
@@ -64,12 +64,12 @@ class _InMemoryFile extends BaseVfsFile {
   _InMemoryFile(this.vfs, this.path, this.deleteOnClose);
 
   @override
-  int readInto(Uint8List buffer, int offset) {
+  int readInto(SafeU8Array buffer, int offset) {
     final file = vfs.fileData[path];
     if (file == null || file.length <= offset) return 0;
 
     final available = min(buffer.length, file.length - offset);
-    buffer.setRange(0, available, file, offset);
+    buffer.set(file.subarray(offset, offset + available).inner, 0);
     return available;
   }
 
@@ -102,9 +102,9 @@ class _InMemoryFile extends BaseVfsFile {
   void xTruncate(int size) {
     final file = vfs.fileData[path];
 
-    final result = Uint8List(size);
+    final result = SafeU8Array.allocate(size);
     if (file != null) {
-      result.setRange(0, min(size, file.length), file);
+      result.set(file.inner, 0);
     }
 
     vfs.fileData[path] = result;
@@ -116,19 +116,18 @@ class _InMemoryFile extends BaseVfsFile {
   }
 
   @override
-  void xWrite(Uint8List buffer, int fileOffset) {
-    final file = vfs.fileData[path] ?? Uint8List(0);
+  void xWrite(SafeU8Array buffer, int fileOffset) {
+    final file = vfs.fileData[path] ?? SafeU8Array.allocate(0);
     final increasedSize = fileOffset + buffer.length - file.length;
 
     if (increasedSize <= 0) {
       // Can write directy
-      file.setRange(fileOffset, fileOffset + buffer.length, buffer);
+      file.set(buffer.inner, fileOffset);
     } else {
       // We need to grow the file first
-      final newFile = Uint8List(file.length + increasedSize)
-        ..setAll(0, file)
-        ..setAll(fileOffset, buffer);
-
+      final newFile = SafeU8Array.allocate(file.length + increasedSize)
+        ..set(file.inner, 0)
+        ..set(buffer.inner, fileOffset);
       vfs.fileData[path] = newFile;
     }
   }

--- a/sqlite3/lib/src/wasm/vfs/simple_opfs.dart
+++ b/sqlite3/lib/src/wasm/vfs/simple_opfs.dart
@@ -1,5 +1,4 @@
 import 'dart:js_interop';
-import 'dart:typed_data';
 
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
@@ -10,7 +9,7 @@ import 'package:web/web.dart'
         FileSystemReadWriteOptions;
 
 import '../../constants.dart';
-import '../../vfs.dart';
+import '../vfs.dart';
 import '../js_interop.dart';
 import 'memory.dart';
 
@@ -59,7 +58,7 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
   // done asynchronously.
 
   final FileSystemSyncAccessHandle _metaHandle;
-  final Uint8List _existsList = Uint8List(FileType.values.length);
+  final SafeU8Array _existsList = SafeU8Array.allocate(FileType.values.length);
 
   final Map<FileType, FileSystemSyncAccessHandle> _files;
   final InMemoryFileSystem _memory = InMemoryFileSystem();
@@ -202,7 +201,7 @@ class _SimpleOpfsFile extends BaseVfsFile {
   _SimpleOpfsFile(this.vfs, this.type, this.syncHandle, this.deleteOnClose);
 
   @override
-  int readInto(Uint8List buffer, int offset) {
+  int readInto(SafeU8Array buffer, int offset) {
     return syncHandle.readDart(buffer, FileSystemReadWriteOptions(at: offset));
   }
 
@@ -246,7 +245,7 @@ class _SimpleOpfsFile extends BaseVfsFile {
   }
 
   @override
-  void xWrite(Uint8List buffer, int fileOffset) {
+  void xWrite(SafeU8Array buffer, int fileOffset) {
     final bytesWritten = syncHandle.writeDart(
         buffer, FileSystemReadWriteOptions(at: fileOffset));
 

--- a/sqlite3/lib/wasm.dart
+++ b/sqlite3/lib/wasm.dart
@@ -24,3 +24,4 @@ export 'src/wasm/vfs/indexed_db.dart' show IndexedDbFileSystem;
 export 'src/wasm/vfs/async_opfs/client.dart' show WasmVfs;
 export 'src/wasm/vfs/async_opfs/worker.dart' show WorkerOptions, VfsWorker;
 export 'src/wasm/sqlite3.dart';
+export 'src/wasm/vfs.dart';

--- a/sqlite3/test/wasm/file_system_test.dart
+++ b/sqlite3/test/wasm/file_system_test.dart
@@ -3,10 +3,12 @@ library;
 
 import 'dart:async';
 import 'dart:developer';
+import 'dart:js_interop';
 import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:sqlite3/wasm.dart';
+import 'package:sqlite3/src/wasm/js_interop/typed_data.dart';
 import 'package:test/test.dart';
 
 import 'utils.dart';
@@ -142,12 +144,12 @@ Future<void> _testWith(FutureOr<VirtualFileSystem> Function() open) async {
     file.xTruncate(0);
     expect(file.xFileSize(), 0);
 
-    file.xWrite(Uint8List.fromList([1, 2, 3]), 0);
+    file.xWrite(SafeU8Array(Uint8List.fromList([1, 2, 3]).toJS), 0);
     expect(file.xFileSize(), 3);
 
-    final target = Uint8List(3);
+    final target = SafeU8Array.allocate(3);
     file.xRead(target, 0);
-    expect(target, [1, 2, 3]);
+    expect(target.inner.toDart, [1, 2, 3]);
   });
 }
 


### PR DESCRIPTION
- As `dart2wasm` can't convert JS typed data instances into Dart instances without copying, we have to avoid `dart:typed_data` pretty much everywhere in code we intend to compile to WASM. This affects the VFS layer which is a breaking change.
- todo there will probably be more changes required.