### PR TITLE
chore: update Gradle configuration

### DIFF
--- a/sqlcipher_flutter_libs/android/build.gradle
+++ b/sqlcipher_flutter_libs/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
+        classpath 'com.android.tools.build:gradle:8.5.1'
     }
 }
 
@@ -22,15 +22,14 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
-
     // Conditional for compatibility with AGP <4.2.
     if (project.android.hasProperty("namespace")) {
         namespace 'eu.simonbinder.sqlite3_flutter_libs'
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
+        compileSdk 34
     }
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
- match minimum SDK version to Flutter's minimum
- migrate compileSdkVersion to compileSdk
- update compileSdk to Flutter's target

Flutter 3.24 increased the minimum SDK version as well as the compile SDK version.

As a result, sqlcipher_flutter_libs does no longer compile since the lower compileSdkVersion caused AAPT to expect `android:attr/lStar` to be available. This is no longer the case.

Related error :

```
build/sqlcipher_flutter_libs/intermediates/merged_res/release/mergeReleaseResources/values/values.xml:195: AAPT: error: resource android:attr/lStar not found.
```