### PR TITLE
`sqlite3_web`: Fix handling worker errors

### DIFF
--- a/sqlite3_web/CHANGELOG.md
+++ b/sqlite3_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.2
+
+- Recover from worker errors at startup.
+
 ## 0.2.1
 
 - Add `WebSqlite.deleteDatabase` to delete databases.

--- a/sqlite3_web/pubspec.yaml
+++ b/sqlite3_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite3_web
 description: Utilities to simplify accessing sqlite3 on the web, with automated feature detection.
-version: 0.2.2-dev
+version: 0.2.2
 homepage: https://github.com/simolus3/sqlite3.dart/tree/main/sqlite3_web
 repository: https://github.com/simolus3/sqlite3.dart
 

--- a/sqlite3_web/test/integration_test.dart
+++ b/sqlite3_web/test/integration_test.dart
@@ -108,21 +108,36 @@ void main() {
       });
 
       setUp(() async {
-        final rawDriver = await createDriver(
-          spec: browser.isChromium ? WebDriverSpec.JsonWire : WebDriverSpec.W3c,
-          uri: browser.driverUri,
-          desired: {
-            'goog:chromeOptions': {
-              'args': [
-                '--headless=new',
-                '--disable-search-engine-choice-screen',
-              ],
-            },
-            'moz:firefoxOptions': {
-              'args': ['-headless']
-            },
-          },
-        );
+        late WebDriver rawDriver;
+        for (var i = 0; i < 3; i++) {
+          try {
+            rawDriver = await createDriver(
+              spec: browser.isChromium
+                  ? WebDriverSpec.JsonWire
+                  : WebDriverSpec.W3c,
+              uri: browser.driverUri,
+              desired: {
+                'goog:chromeOptions': {
+                  'args': [
+                    '--headless=new',
+                    '--disable-search-engine-choice-screen',
+                  ],
+                },
+                'moz:firefoxOptions': {
+                  'args': ['-headless']
+                },
+              },
+            );
+            break;
+          } on SocketException {
+            // webdriver server taking a bit longer to start up...
+            if (i == 2) {
+              rethrow;
+            }
+
+            await Future.delayed(const Duration(milliseconds: 500));
+          }
+        }
 
         // logs.get() isn't supported on Firefox
         if (browser != Browser.firefox) {


### PR DESCRIPTION
It's not that constructing the `Worker` throws, an error event is emitted that is currently not handled (meaning that the initialization future never completes). This refactors that to throw an error that is then caught and handled.