### PR TITLE
Try loading winsqlite3.dll on Windows

### DIFF
--- a/sqlite3/lib/src/ffi/load_library.dart
+++ b/sqlite3/lib/src/ffi/load_library.dart
@@ -86,7 +86,11 @@ DynamicLibrary _defaultOpen() {
     }
     return result;
   } else if (Platform.isWindows) {
-    return DynamicLibrary.open('sqlite3.dll');
+    try {
+      return return DynamicLibrary.open('sqlite3.dll');
+    } on ArgumentError catch (_) {
+      return DynamicLibrary.open('winsqlite3.dll');
+    }
   }
 
   throw UnsupportedError('Unsupported platform: ${Platform.operatingSystem}');


### PR DESCRIPTION
Windows ships with a `sqlite3` dll under the name `winsqlite3` since a couple of years. Similar to macOS and Linux this can be used, if no override has been provided