### PR TITLE
Fix sending update notifications

### DIFF
--- a/sqlite3_web/CHANGELOG.md
+++ b/sqlite3_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Fix hooks not being delivered to all databases.
+
 ## 0.3.0
 
 - Allow passing data to worker when opening databases.

--- a/sqlite3_web/lib/src/worker.dart
+++ b/sqlite3_web/lib/src/worker.dart
@@ -249,8 +249,8 @@ final class _ClientConnection extends ProtocolChannel
         return await subscribe(database!.updates, () async {
           final rawDatabase = await database.database.opened;
           return rawDatabase.database.updates.listen((event) {
-            sendNotification(UpdateNotification(
-                update: event, databaseId: database.database.id));
+            sendNotification(
+                UpdateNotification(update: event, databaseId: database.id));
           });
         }, request);
       case StreamRequest(action: true, type: MessageType.commitRequest):
@@ -258,8 +258,7 @@ final class _ClientConnection extends ProtocolChannel
           final rawDatabase = await database.database.opened;
           return rawDatabase.database.commits.listen((event) {
             sendNotification(EmptyNotification(
-                type: MessageType.notifyCommit,
-                databaseId: database.database.id));
+                type: MessageType.notifyCommit, databaseId: database.id));
           });
         }, request);
       case StreamRequest(action: true, type: MessageType.rollbackRequest):
@@ -267,8 +266,7 @@ final class _ClientConnection extends ProtocolChannel
           final rawDatabase = await database.database.opened;
           return rawDatabase.database.rollbacks.listen((event) {
             sendNotification(EmptyNotification(
-                type: MessageType.notifyRollback,
-                databaseId: database.database.id));
+                type: MessageType.notifyRollback, databaseId: database.id));
           });
         }, request);
       case StreamRequest(action: false):
@@ -468,6 +466,7 @@ final class DatabaseState {
 
   Future<void> decrementRefCount() async {
     if (--refCount == 0) {
+      print('closing database $id, $name, $mode');
       await close();
     }
   }
@@ -614,6 +613,7 @@ final class WorkerRunner {
     }
 
     final id = _nextDatabaseId++;
+    print('opening new database, $name, $mode with id $id');
     return openedDatabases[id] = DatabaseState(
       id: id,
       runner: this,

--- a/sqlite3_web/lib/src/worker.dart
+++ b/sqlite3_web/lib/src/worker.dart
@@ -466,7 +466,6 @@ final class DatabaseState {
 
   Future<void> decrementRefCount() async {
     if (--refCount == 0) {
-      print('closing database $id, $name, $mode');
       await close();
     }
   }
@@ -613,7 +612,6 @@ final class WorkerRunner {
     }
 
     final id = _nextDatabaseId++;
-    print('opening new database, $name, $mode with id $id');
     return openedDatabases[id] = DatabaseState(
       id: id,
       runner: this,

--- a/sqlite3_web/pubspec.yaml
+++ b/sqlite3_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sqlite3_web
 description: Utilities to simplify accessing sqlite3 on the web, with automated feature detection.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/simolus3/sqlite3.dart/tree/main/sqlite3_web
 repository: https://github.com/simolus3/sqlite3.dart
 

--- a/sqlite3_web/test/integration_test.dart
+++ b/sqlite3_web/test/integration_test.dart
@@ -258,5 +258,9 @@ final class _TestConfiguration {
         await driver.checkReadWrite();
       });
     }
+
+    test('can share databases', () async {
+      await driver.testSecond();
+    });
   }
 }

--- a/sqlite3_web/tool/server.dart
+++ b/sqlite3_web/tool/server.dart
@@ -187,7 +187,7 @@ class TestWebDriver {
     await driver.executeAsync('exec(arguments[0], arguments[1])', [sql]);
   }
 
-  Future<void> testSecond(String sql) async {
+  Future<void> testSecond() async {
     final res = await driver.executeAsync('test_second("", arguments[0])', []);
     if (res != true) {
       throw 'test_second failed! More information may be available in the console.';


### PR DESCRIPTION
The id of databases as assigned by the worker are global (`database.database.id`), but there's also a per-connection id for databases (`database.id`).

These are not guaranteed to be the same, and a mismatch causes clients to ignore update notifications. This can be triggered if one client opens multiple connections and shares one with `OpenAdditonalConnection`, since connections obtained through `OpenAdditonalConnection` always have an id of zero.