### PR TITLE
Fix a typo in README of sqlite3-native-assets

### DIFF
--- a/sqlite3_native_assets/README.md
+++ b/sqlite3_native_assets/README.md
@@ -7,7 +7,7 @@ except that it works without Flutter.
 
 ## Getting started
 
-Add this package to your dependencies: `dart pub add sqlite3_native_assetes`.
+Add this package to your dependencies: `dart pub add sqlite3_native_assets`.
 That's it! No build scripts to worry about, it works out of the box.
 
 ## Usage


### PR DESCRIPTION
I just stumbled across your package from reading your blog post and saw a typo in the name for the package in the ``README.md``. Thanks for all the amazing work you do in this community.