### PR TITLE
Fix for temporary files in Dart VFS

### DIFF
--- a/sqlite3/lib/src/ffi/bindings.dart
+++ b/sqlite3/lib/src/ffi/bindings.dart
@@ -242,7 +242,8 @@ final class _RegisteredVfs {
   static int _xOpen(Pointer<sqlite3_vfs> vfsPtr, Pointer<Char> zName,
       Pointer<sqlite3_file> file, int flags, Pointer<Int> pOutFlags) {
     return _runVfs(vfsPtr, (vfs) {
-      final fileName = Sqlite3Filename(zName.cast<sqlite3_char>().readString());
+      final fileName = Sqlite3Filename(
+          zName.isNullPointer ? null : zName.cast<sqlite3_char>().readString());
       final dartFilePtr = file.cast<_DartFile>();
 
       final (file: dartFile, :outFlags) = vfs.xOpen(fileName, flags);


### PR DESCRIPTION
When using a Dart VFS such as InMemoryFileSystem, and temporary storage is used, I get a segfault here:

```
  pc 0x00007ab23fba52a3 fp 0x00007ab26017caa8 [Optimized] _loadUint8@9050071+0x23
  pc 0x00007ab23fba523d fp 0x00007ab26017cae0 [Unoptimized] Uint8Pointer|[]+0x6d
  pc 0x00007ab23fba4ec3 fp 0x00007ab26017cb28 [Unoptimized] Utf8Utils|get#_length+0xe3
  pc 0x00007ab23fba4cd9 fp 0x00007ab26017cb90 [Unoptimized] Utf8Utils|readString+0x149
  pc 0x00007ab23fbc0e34 fp 0x00007ab26017cc10 [Unoptimized] _RegisteredVfs@162042778._xOpen@162042778.<anonymous closure>+0xe4
  pc 0x00007ab23fbbf5cc fp 0x00007ab26017cc78 [Unoptimized] _RegisteredVfs@162042778._runVfs@162042778+0x19c
  pc 0x00007ab23fbc0ca4 fp 0x00007ab26017ccb0 [Unoptimized] _RegisteredVfs@162042778._xOpen@162042778+0x184
  pc 0x00007ab23fbb29c6 fp 0x00007ab26017cd60 [Optimized] _FfiCallback_xOpen@162042778+0x196
  pc 0x00007ab26fd03390 fp 0x00007ab26017cdc8 Unknown symbol
  pc 0x0000000000000000 fp 0x00007ab26017ce00 Unknown symbol
  pc 0x00007ab27064106e fp 0x00007ab26017ce60 Unknown symbol
  pc 0x00007ab23f897601 fp 0x00007ab26017ceb0 /lib/x86_64-linux-gnu/libsqlite3.so.0+0x108601
...
```

The null filename passed to xOpen is correctly handled in the InMemoryFileSystem implementation, but not in the native bindings. This change fixes the issue for me.