### PR TITLE
Add `updatesSync` stream

### DIFF
--- a/sqlite3/CHANGELOG.md
+++ b/sqlite3/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.9.0
+
+- Add `CommonDatabase.updatesSync`, a synchronous variant of the updates stream.
+
 ## 2.8.0
 
 - Support creating changesets and patchsets via the session extension.

--- a/sqlite3/lib/src/database.dart
+++ b/sqlite3/lib/src/database.dart
@@ -51,7 +51,20 @@ abstract class CommonDatabase {
   ///
   /// See also:
   ///  - [Data Change Notification Callbacks](https://www.sqlite.org/c3ref/update_hook.html)
+  ///  - [updatesSync], a synchronous stream.
   Stream<SqliteUpdate> get updates;
+
+  /// A _synchronous_ stream of data changes happening on this database.
+  ///
+  /// This stream behaves similarly to [updates], except that listeners are
+  /// invoked synchronously (before the update completes).
+  ///
+  /// The purpose of this stream is to avoid a large internal buffer when a
+  /// transaction updates a large amount of rows - instead, the updates can be
+  /// handled one-by-one with this.
+  ///
+  /// It is crucial that listeners on this stream don't modify the database.
+  Stream<SqliteUpdate> get updatesSync;
 
   /// The [VoidPredicate] that is used to filter out transactions before commiting.
   ///

--- a/sqlite3/test/common/database.dart
+++ b/sqlite3/test/common/database.dart
@@ -747,6 +747,20 @@ void testDatabase(
       expect(database.updates.listen(null).asFuture(null), completes);
       database.dispose();
     });
+
+    test('can listen synchronously', () async {
+      var notifications = 0;
+      var asyncNotifications = 0;
+
+      database.updatesSync.listen((_) => notifications++);
+      database.updates.listen((_) => asyncNotifications++);
+
+      database.execute('INSERT INTO tbl DEFAULT VALUES');
+      expect(notifications, 1);
+      expect(asyncNotifications, 0);
+      await pumpEventQueue();
+      expect(asyncNotifications, 1);
+    });
   });
 
   group('rollback stream', () {


### PR DESCRIPTION
This adds a synchronous variant of the `CommonDatabase.update` streams to avoid internal buffers for large transactions.