### PR TITLE
web: allow executing multiple statements

### DIFF
--- a/sqlite3_web/lib/src/client.dart
+++ b/sqlite3_web/lib/src/client.dart
@@ -150,6 +150,29 @@ final class RemoteDatabase implements Database {
   }
 
   @override
+  Future<void> executeMultiple(
+    String sql, {
+    bool checkInTransaction = false,
+    LockToken? token,
+    Future<void>? abortTrigger,
+  }) async {
+    await connection.sendRequest(
+      RunQuery(
+        requestId: 0,
+        databaseId: databaseId,
+        lockId: token == null ? null : lockTokenToId(token),
+        sql: sql,
+        parameters: const [],
+        returnRows: false,
+        checkInTransaction: checkInTransaction,
+        multipleStatements: true,
+      ),
+      MessageType.simpleSuccessResponse,
+      abortTrigger: abortTrigger,
+    );
+  }
+
+  @override
   Future<T> requestLock<T>(Future<T> Function(LockToken token) body,
       {Future<void>? abortTrigger}) async {
     final response = await connection.sendRequest(

--- a/sqlite3_web/lib/src/database.dart
+++ b/sqlite3_web/lib/src/database.dart
@@ -112,6 +112,24 @@ abstract class Database {
     Future<void>? abortTrigger,
   });
 
+  /// Prepares each statement [sql] and executes them each, sequentially. If
+  /// any sequence fails, the execution is aborted without running the
+  /// remaining statements.
+  ///
+  /// If [checkInTransaction] is enabled, the host will verify that the
+  /// autocommit mode is disabled before running the statements (and report an
+  /// exception otherwise).
+  ///
+  /// The [abortTrigger] can be used to abort the request. When that future
+  /// completes before the lock has been granted, the future may complete
+  /// with a [AbortException] without running the statements.
+  Future<void> executeMultiple(
+    String sql, {
+    bool checkInTransaction = false,
+    LockToken? token,
+    Future<void>? abortTrigger,
+  });
+
   /// Prepares [sql], executes it with the given [parameters] and returns the
   /// [ResultSet].
   ///

--- a/sqlite3_web/lib/src/protocol.dart
+++ b/sqlite3_web/lib/src/protocol.dart
@@ -123,6 +123,7 @@ class _UniqueFieldNames {
   static const autocommit = 'x';
   static const lastInsertRowid = 'y';
   static const lockId = 'z';
+  static const multipleStatements = 'm';
 }
 
 sealed class Message {
@@ -563,6 +564,7 @@ final class RunQuery extends Request {
   final int? lockId;
   final bool returnRows;
   final bool checkInTransaction;
+  final bool multipleStatements;
 
   RunQuery({
     required super.requestId,
@@ -572,6 +574,7 @@ final class RunQuery extends Request {
     required this.lockId,
     required this.returnRows,
     required this.checkInTransaction,
+    this.multipleStatements = false,
   });
 
   factory RunQuery.deserialize(JSObject object) {
@@ -587,6 +590,9 @@ final class RunQuery extends Request {
       returnRows: (object[_UniqueFieldNames.returnRows] as JSBoolean).toDart,
       checkInTransaction:
           (object[_UniqueFieldNames.checkInTransaction] as JSBoolean).toDart,
+      multipleStatements:
+          (object[_UniqueFieldNames.multipleStatements] as JSBoolean?)?.toDart ??
+              false,
     );
   }
 
@@ -611,6 +617,7 @@ final class RunQuery extends Request {
     }
 
     object[_UniqueFieldNames.checkInTransaction] = checkInTransaction.toJS;
+    object[_UniqueFieldNames.multipleStatements] = multipleStatements.toJS;
   }
 
   @override

--- a/sqlite3_web/test/protocol_test.dart
+++ b/sqlite3_web/test/protocol_test.dart
@@ -137,6 +137,30 @@ void main() {
     );
   });
 
+  test('serializes multipleStatements flag', () async {
+    server.handleRequestFunction = expectAsync1((request) async {
+      final run = request as RunQuery;
+      expect(run.sql, 'CREATE TABLE a (x); CREATE TABLE b (y);');
+      expect(run.multipleStatements, true);
+      expect(run.returnRows, false);
+      return SimpleSuccessResponse(requestId: request.requestId, response: null);
+    });
+
+    await client.sendRequest(
+      RunQuery(
+        requestId: 0,
+        databaseId: 0,
+        sql: 'CREATE TABLE a (x); CREATE TABLE b (y);',
+        checkInTransaction: false,
+        lockId: null,
+        parameters: [],
+        returnRows: false,
+        multipleStatements: true,
+      ),
+      MessageType.simpleSuccessResponse,
+    );
+  });
+
   test('can serialize SqliteExceptions', () async {
     server.handleRequestFunction = expectAsync1((req) {
       throw SqliteException(


### PR DESCRIPTION
Adds a method that allows executing multiple statements from a single sql string. 
See https://github.com/powersync-ja/sqlite_async.dart/pull/123 and https://github.com/powersync-ja/sqlite_async.dart/issues/122 for context.

Disclaimer: I have not taken the time to set up the test dependencies on my my machine yet. 

