### PR TITLE
Hook: Use consistent output filename

### DIFF
--- a/sqlite3/CHANGELOG.md
+++ b/sqlite3/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.5
+
+- Build hook: Ensure we use consistent filenames to fix issues on Apple platforms.
+
 ## 3.1.4
 
 - Build hook: Fix paths not resolving on Windows when building from source.

--- a/sqlite3/hook/build.dart
+++ b/sqlite3/hook/build.dart
@@ -20,28 +20,18 @@ void main(List<String> args) async {
         final library = sqlite.resolveLibrary(input.config.code);
         library.checkSupported();
 
-        final dir = Directory(
-          input.outputDirectoryShared.resolve(library.dirname).toFilePath(),
+        final downloaded = await sqlite.downloadIntoOutputDirectoryShared(
+          input,
+          output,
+          library,
         );
-        if (!dir.existsSync()) {
-          dir.createSync();
-        }
-
-        final target = File(p.join(dir.path, library.filename));
-        final tmp = File('${target.path}.tmp');
-
-        await sqlite
-            .fetch(input, output, library)
-            .cast<List<int>>()
-            .pipe(tmp.openWrite());
-        tmp.renameSync(target.path);
 
         output.assets.code.add(
           CodeAsset(
             package: package,
             name: name,
             linkMode: DynamicLoadingBundled(),
-            file: target.uri,
+            file: downloaded.uri,
           ),
         );
       case CompileSqlite(:final sourceFile, :final defines):

--- a/sqlite3/lib/src/hook/assets.dart
+++ b/sqlite3/lib/src/hook/assets.dart
@@ -87,7 +87,8 @@ final class PrebuiltSqliteLibrary {
     return !unsupportedCiphersBuild;
   }
 
-  String get filename {
+  /// The name of this prebuilt library in GitHub releases.
+  String get sourceFilename {
     if (!isSupported) {
       throw StateError('Unsupported binary does not have a filename');
     }


### PR DESCRIPTION
The hook should not emit filenames like `libsqlite3.ios.arm64.dylib` because that makes the generated filenames harder to bundle into a framework.

We're already using a unique directory in `outputDirectoryShared` that depends on the target ABI. So we can just use `libsqlite3.dylib` in there instead of trying to generate a unique filename.

This also adds a check to reuse existing files if they already exist.

Closes https://github.com/simolus3/sqlite3.dart/issues/348.