### PR TITLE
Improvements to OPFS file systems

### DIFF
--- a/sqlite3/lib/src/wasm/vfs/simple_opfs.dart
+++ b/sqlite3/lib/src/wasm/vfs/simple_opfs.dart
@@ -230,10 +230,9 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
     final deleteOnClose = (flags & SqlFlag.SQLITE_OPEN_DELETEONCLOSE) != 0;
     final existsAlready = files.exists(recognized);
 
-    final syncHandle = files.handleFor(recognized);
-
     if (!existsAlready) {
       if (create) {
+        final syncHandle = files.handleFor(recognized);
         syncHandle.truncate(0);
         files.markExists(recognized, true);
       } else {
@@ -243,7 +242,7 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
 
     return (
       outFlags: 0,
-      file: _SimpleOpfsFile(this, recognized, syncHandle, deleteOnClose),
+      file: _SimpleOpfsFile(this, recognized, deleteOnClose),
     );
   }
 
@@ -291,12 +290,14 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
 class _SimpleOpfsFile extends BaseVfsFile {
   final SimpleOpfsFileSystem vfs;
   final FileType type;
-  final FileSystemSyncAccessHandle syncHandle;
   final bool deleteOnClose;
 
   var _lockMode = SqlFileLockingLevels.SQLITE_LOCK_NONE;
 
-  _SimpleOpfsFile(this.vfs, this.type, this.syncHandle, this.deleteOnClose);
+  FileSystemSyncAccessHandle get syncHandle =>
+      vfs._requireFiles().handleFor(type);
+
+  _SimpleOpfsFile(this.vfs, this.type, this.deleteOnClose);
 
   @override
   int readInto(Uint8List buffer, int offset) {

--- a/sqlite3/lib/src/wasm/vfs/simple_opfs.dart
+++ b/sqlite3/lib/src/wasm/vfs/simple_opfs.dart
@@ -60,17 +60,17 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
   // the FileSystem Access API to check whether a file exists, which can only be
   // done asynchronously.
 
-  final FileSystemSyncAccessHandle _metaHandle;
-  final Uint8List _existsList = Uint8List(FileType.values.length);
+  _OpfsFiles? _files;
 
-  final Map<FileType, FileSystemSyncAccessHandle> _files;
+  /// An in-memory overlay used for files that aren't persisted (e.g. temporary
+  /// materialized views).
   final InMemoryFileSystem _memory = InMemoryFileSystem();
 
-  SimpleOpfsFileSystem._(
-    this._metaHandle,
-    this._files, {
-    String vfsName = 'simple-opfs',
-  }) : super(name: vfsName);
+  /// Creates an OPFS-based file system in a closed state.
+  ///
+  /// Before using this file system, call [open] to load the required access
+  /// handles.
+  SimpleOpfsFileSystem({String vfsName = 'simple-opfs'}) : super(name: vfsName);
 
   static Future<(FileSystemDirectoryHandle?, FileSystemDirectoryHandle)>
   _resolveDir(String path, {bool create = true}) async {
@@ -88,6 +88,18 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
     }
 
     return (parent, opfsDirectory);
+  }
+
+  /// Resolves a [FileSystemDirectoryHandle] from a path resolved against the
+  /// OPFS root.
+  ///
+  /// The directory is created recursively if [create] is enabled (the default).
+  static Future<FileSystemDirectoryHandle> resolveDirectory(
+    String path, {
+    bool create = true,
+  }) async {
+    final (_, handle) = await _resolveDir(path, create: create);
+    return handle;
   }
 
   /// Loads an [SimpleOpfsFileSystem] in the desired [path] under the root directory
@@ -111,7 +123,7 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
       throw VfsException(SqlError.SQLITE_ERROR);
     }
 
-    final (_, directory) = await _resolveDir(path);
+    final directory = await resolveDirectory(path);
     return inDirectory(
       directory,
       vfsName: vfsName,
@@ -163,30 +175,16 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
     String vfsName = 'simple-opfs',
     bool readWriteUnsafe = false,
   }) async {
-    Future<FileSystemSyncAccessHandle> open(String name) async {
-      final handle = await root.openFile(name, create: true);
-
-      final syncHandlePromise = readWriteUnsafe
-          ? ProposedLockingSchemeApi(handle).createSyncAccessHandle(
-              FileSystemCreateSyncAccessHandleOptions.unsafeReadWrite(),
-            )
-          : handle.createSyncAccessHandle();
-
-      return await syncHandlePromise.toDart;
-    }
-
-    final meta = await open('meta');
-    meta.truncate(2);
-    final files = {
-      for (final type in FileType.values) type: await open(type.name),
-    };
-
-    return SimpleOpfsFileSystem._(meta, files, vfsName: vfsName);
+    final fs = SimpleOpfsFileSystem(vfsName: vfsName);
+    await fs.open(root, readWriteUnsafe: readWriteUnsafe);
+    return fs;
   }
 
-  void _markExists(FileType type, bool exists) {
-    _existsList[type.index] = exists ? 1 : 0;
-    _metaHandle.writeDart(_existsList, FileSystemReadWriteOptions(at: 0));
+  _OpfsFiles _requireFiles() {
+    if (_files case final files?) {
+      return files;
+    }
+    throw StateError('VFS closed');
   }
 
   FileType? _recognizeType(String path) {
@@ -199,8 +197,8 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
     if (type == null) {
       return _memory.xAccess(path, flags);
     } else {
-      _metaHandle.readDart(_existsList, FileSystemReadWriteOptions(at: 0));
-      return _existsList[type.index];
+      final files = _requireFiles();
+      return files.exists(type) ? 1 : 0;
     }
   }
 
@@ -210,7 +208,7 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
     if (type == null) {
       return _memory.xDelete(path, syncDir);
     } else {
-      _markExists(type, false);
+      _requireFiles().markExists(type, false);
     }
   }
 
@@ -227,18 +225,17 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
     final recognized = _recognizeType(pathStr);
     if (recognized == null) return _memory.xOpen(path, flags);
 
+    final files = _requireFiles();
     final create = (flags & SqlFlag.SQLITE_OPEN_CREATE) != 0;
     final deleteOnClose = (flags & SqlFlag.SQLITE_OPEN_DELETEONCLOSE) != 0;
+    final existsAlready = files.exists(recognized);
 
-    _metaHandle.readDart(_existsList, FileSystemReadWriteOptions(at: 0));
-    final existsAlready = _existsList[recognized.index] != 0;
-
-    final syncHandle = _files[recognized]!;
+    final syncHandle = files.handleFor(recognized);
 
     if (!existsAlready) {
       if (create) {
         syncHandle.truncate(0);
-        _markExists(recognized, true);
+        files.markExists(recognized, true);
       } else {
         throw const VfsException(SqlError.SQLITE_CANTOPEN);
       }
@@ -255,11 +252,39 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
 
   /// Closes the synchronous access handles kept open while this file system is
   /// active.
+  ///
+  /// This file system can be re-opened afterwards with [open].
   void close() {
-    _metaHandle.close();
-    for (final file in _files.values) {
-      file.close();
+    _files?.close();
+    _files = null;
+  }
+
+  /// Re-opens a file system previously closed with [close].
+  @experimental
+  Future<void> open(
+    FileSystemDirectoryHandle root, {
+    bool readWriteUnsafe = false,
+  }) async {
+    assert(_files == null);
+
+    Future<FileSystemSyncAccessHandle> open(String name) async {
+      final handle = await root.openFile(name, create: true);
+
+      final syncHandlePromise = readWriteUnsafe
+          ? ProposedLockingSchemeApi(handle).createSyncAccessHandle(
+              FileSystemCreateSyncAccessHandleOptions.unsafeReadWrite(),
+            )
+          : handle.createSyncAccessHandle();
+
+      return await syncHandlePromise.toDart;
     }
+
+    final meta = await open('meta');
+    meta.truncate(2);
+
+    final database = await open(FileType.database.name);
+    final journal = await open(FileType.journal.name);
+    _files = _OpfsFiles(meta, database, journal);
   }
 }
 
@@ -288,7 +313,7 @@ class _SimpleOpfsFile extends BaseVfsFile {
     syncHandle.flush();
 
     if (deleteOnClose) {
-      vfs._markExists(type, false);
+      vfs._requireFiles().markExists(type, false);
     }
   }
 
@@ -327,5 +352,38 @@ class _SimpleOpfsFile extends BaseVfsFile {
     if (bytesWritten < buffer.length) {
       throw const VfsException(SqlExtendedError.SQLITE_IOERR_WRITE);
     }
+  }
+}
+
+final class _OpfsFiles {
+  final Uint8List _existsList = Uint8List(FileType.values.length);
+
+  final FileSystemSyncAccessHandle metaHandle;
+  final FileSystemSyncAccessHandle database;
+  final FileSystemSyncAccessHandle journal;
+
+  _OpfsFiles(this.metaHandle, this.database, this.journal);
+
+  bool exists(FileType type) {
+    metaHandle.readDart(_existsList, FileSystemReadWriteOptions(at: 0));
+    return _existsList[type.index] != 0;
+  }
+
+  void markExists(FileType type, bool exists) {
+    _existsList[type.index] = exists ? 1 : 0;
+    metaHandle.writeDart(_existsList, FileSystemReadWriteOptions(at: 0));
+  }
+
+  FileSystemSyncAccessHandle handleFor(FileType type) {
+    return switch (type) {
+      FileType.database => database,
+      FileType.journal => journal,
+    };
+  }
+
+  void close() {
+    metaHandle.close();
+    database.close();
+    journal.close();
   }
 }

--- a/sqlite3/lib/src/wasm/vfs/simple_opfs.dart
+++ b/sqlite3/lib/src/wasm/vfs/simple_opfs.dart
@@ -279,11 +279,19 @@ final class SimpleOpfsFileSystem extends BaseVirtualFileSystem {
     }
 
     final meta = await open('meta');
+    // The meta file did not exist before, this can happen when migrating from
+    // OPFS with atomics to this VFS.
+    final migratingFromOpfsAtomics = meta.getSize() == 0;
     meta.truncate(2);
 
     final database = await open(FileType.database.name);
     final journal = await open(FileType.journal.name);
-    _files = _OpfsFiles(meta, database, journal);
+
+    final files = _files = _OpfsFiles(meta, database, journal);
+    if (migratingFromOpfsAtomics) {
+      files.markExists(FileType.database, database.getSize() > 0);
+      files.markExists(FileType.journal, journal.getSize() > 0);
+    }
   }
 }
 

--- a/sqlite3_web/CHANGELOG.md
+++ b/sqlite3_web/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## 0.8.0 (unreleased)
 
 - Remove `stream_channel` dependency with custom implementation, slightly decreasing compiled size.
-- Use strings instead of URLs to reduce code size.
-- Custom Dart objects can no longer be serialized via `serializeParameters` and `serializeResultSet`.
+- __Breaking__: Use strings instead of URLs to reduce code size.
+- __Breaking__: Custom Dart objects can no longer be serialized via `serializeParameters` and `serializeResultSet`.
   Only SQLite values are supported.
+- __Breaking__: Remove `opfsAtomics` file system implementation. The new `opfsWithExternalLocksWorkaround` supports
+  the same browsers while being faster and not requiring special headers.
 - Fix raw file system writes not acquiring database locks.
 - Optimize use of navigator locks to avoid acquiring them in single-tab scenarios.
 

--- a/sqlite3_web/CHANGELOG.md
+++ b/sqlite3_web/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Use strings instead of URLs to reduce code size.
 - Custom Dart objects can no longer be serialized via `serializeParameters` and `serializeResultSet`.
   Only SQLite values are supported.
+- Fix raw file system writes not acquiring database locks.
 
 ## 0.7.1
 

--- a/sqlite3_web/CHANGELOG.md
+++ b/sqlite3_web/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Custom Dart objects can no longer be serialized via `serializeParameters` and `serializeResultSet`.
   Only SQLite values are supported.
 - Fix raw file system writes not acquiring database locks.
+- Optimize use of navigator locks to avoid acquiring them in single-tab scenarios.
 
 ## 0.7.1
 

--- a/sqlite3_web/extra/js-package/README.md
+++ b/sqlite3_web/extra/js-package/README.md
@@ -1,4 +1,4 @@
-# sqlite3_web
+# sqlite3-web
 
 Small, fast, convenient bindings for SQLite on the web.
 
@@ -9,15 +9,13 @@ It's designed with a batteries-included approach, and provides:
 
 1. Runtime feature detection: This package automatically picks a suitable database implementation (IndexedDB or OPFS)
    depending on what the current browser supports.
-2. Automatic worker management: For performance, database are accessed through a web workers managed by this library.
+2. Automatic worker management: For performance, databases are accessed through web workers managed by this library.
 3. APIs to access the underlying file system of the worker, which can be used to read and write to database files.
 4. A fully-featured SQLite build, with fts5, rtree, math, dbstat and session extensions enabled by default.
 5. Encryption support with SQLite3 Multiple Ciphers.
 
-The library itself is around 10 KB in size (uncompressed). Additionally, this includes a 220 KB web worker
-and a 750 KB WebAssembly file for SQLite.
-
-Before compression, this library is around 230KB in size (10 KB library + 220 KB worker).
+Before compression, the library itself is around 10 KB in size. Additionally, this includes a 220 KB
+web worker and a 750 KB WebAssembly file for SQLite.
 
 ## Setup
 

--- a/sqlite3_web/extra/js-package/src/api.ts
+++ b/sqlite3_web/extra/js-package/src/api.ts
@@ -88,6 +88,19 @@ export class DatabaseImplementation extends Object {
   );
 
   /**
+   * Opens a synchronous database stored in OPFS.
+   *
+   * This is similar to {@link opfsWithExternalLocks}, but also supports browsers without `readwrite-unsafe`.
+   * It works by opening file handles on most database accessses, which is substantially slower.
+   */
+  static readonly opfsWithExternalLocksWorkaround = new DatabaseImplementation(
+    "opfsWithExternalLocksWorkaround",
+    20,
+    opfs,
+    throughDedicatedWorker,
+  );
+
+  /**
    * Open a synchronous database stored in OPFS.
    *
    * This works by letting a shared worker spawn a dedicated worker. This is supposed to work according to web

--- a/sqlite3_web/extra/js-package/src/api.ts
+++ b/sqlite3_web/extra/js-package/src/api.ts
@@ -90,17 +90,6 @@ export class DatabaseImplementation extends Object {
   );
 
   /**
-   * Open an asynchronous database stored in OPFS. It is "syncified" by using a pair of two dedicated workers
-   * implementing an RPC channel over shared array buffers and atomics.
-   */
-  static readonly opfsAtomics = new DatabaseImplementation(
-    "opfsAtomics",
-    20,
-    opfs,
-    throughDedicatedWorker,
-  );
-
-  /**
    * Open a synchronous database stored in OPFS.
    *
    * This works by letting a shared worker spawn a dedicated worker. This is supposed to work according to web
@@ -132,8 +121,7 @@ export type MissingBrowserFeature =
   | "dedicatedWorkersCanNest"
   | "fileSystemAccess"
   | "createSyncAccessHandleReadWriteUnsafe"
-  | "indexedDb"
-  | "sharedArrayBuffers";
+  | "indexedDb";
 
 /**
  * The result of {@link WebSqlite.runFeatureDetection}, describing which browser features and databases are currently

--- a/sqlite3_web/extra/js-package/src/api.ts
+++ b/sqlite3_web/extra/js-package/src/api.ts
@@ -77,17 +77,6 @@ export class DatabaseImplementation extends Object {
   );
 
   /**
-   * Open an asynchronous database stored in OPFS. It is "syncified" by using a pair of two dedicated workers
-   * implementing an RPC channel over shared array buffers and atomics.
-   */
-  static readonly opfsAtomics = new DatabaseImplementation(
-    "opfsAtomics",
-    21,
-    opfs,
-    throughDedicatedWorker,
-  );
-
-  /**
    * Opens a synchronous database stored in OPFS.
    *
    * This is similar to {@link opfsWithExternalLocks}, but also supports browsers without `readwrite-unsafe`.
@@ -95,6 +84,17 @@ export class DatabaseImplementation extends Object {
    */
   static readonly opfsWithExternalLocksWorkaround = new DatabaseImplementation(
     "opfsWithExternalLocksWorkaround",
+    21,
+    opfs,
+    throughDedicatedWorker,
+  );
+
+  /**
+   * Open an asynchronous database stored in OPFS. It is "syncified" by using a pair of two dedicated workers
+   * implementing an RPC channel over shared array buffers and atomics.
+   */
+  static readonly opfsAtomics = new DatabaseImplementation(
+    "opfsAtomics",
     20,
     opfs,
     throughDedicatedWorker,

--- a/sqlite3_web/extra/js-package/src/api.ts
+++ b/sqlite3_web/extra/js-package/src/api.ts
@@ -118,7 +118,6 @@ export type MissingBrowserFeature =
   | "sharedWorkers"
   | "dedicatedWorkers"
   | "dedicatedWorkersInSharedWorkers"
-  | "dedicatedWorkersCanNest"
   | "fileSystemAccess"
   | "createSyncAccessHandleReadWriteUnsafe"
   | "indexedDb";

--- a/sqlite3_web/extra/js-package/src/channel.ts
+++ b/sqlite3_web/extra/js-package/src/channel.ts
@@ -112,9 +112,6 @@ export abstract class ProtocolChannel {
     const self = this;
 
     dispatchMessage(message, {
-      _internal_whenStartFileSystemServer() {
-        throw new Error("Should only be a top-level message.");
-      },
       _internal_whenAbortRequest() {
         // We don't currently support aborting requests handled on this side.
       },

--- a/sqlite3_web/extra/js-package/src/client.ts
+++ b/sqlite3_web/extra/js-package/src/client.ts
@@ -282,7 +282,6 @@ export class DatabaseClient implements WebSqlite {
       handleCompatibilityResult(result);
       const canUseOpfs = result.c;
       const canUseIndexedDb = result.d;
-      const dedicatedWorkersCanNest = result.f;
       const opfsSupportsReadWriteUnsafe = result.g;
 
       if (!canUseOpfs) {
@@ -293,9 +292,6 @@ export class DatabaseClient implements WebSqlite {
       }
       if (!opfsSupportsReadWriteUnsafe) {
         this.#missingFeatures.add("createSyncAccessHandleReadWriteUnsafe");
-      }
-      if (!dedicatedWorkersCanNest) {
-        this.#missingFeatures.add("dedicatedWorkersCanNest");
       }
 
       if (canUseOpfs) {
@@ -394,7 +390,8 @@ export class DatabaseClient implements WebSqlite {
         ) {
           internalFileSystemImpl = "x";
         } else if (
-          implementation === DatabaseImplementation.opfsWithExternalLocksWorkaround
+          implementation ===
+          DatabaseImplementation.opfsWithExternalLocksWorkaround
         ) {
           internalFileSystemImpl = "y";
         } else {

--- a/sqlite3_web/extra/js-package/src/client.ts
+++ b/sqlite3_web/extra/js-package/src/client.ts
@@ -302,11 +302,15 @@ export class DatabaseClient implements WebSqlite {
         this.#missingFeatures.add("dedicatedWorkersCanNest");
       }
 
-      if (canUseOpfs && supportsSharedArrayBuffers && dedicatedWorkersCanNest) {
-        available.push(DatabaseImplementation.opfsAtomics);
-      }
-      if (canUseOpfs && opfsSupportsReadWriteUnsafe) {
-        available.push(DatabaseImplementation.opfsWithExternalLocks);
+      if (canUseOpfs) {
+        available.push(DatabaseImplementation.opfsWithExternalLocksWorkaround);
+
+        if (supportsSharedArrayBuffers && dedicatedWorkersCanNest) {
+          available.push(DatabaseImplementation.opfsAtomics);
+        }
+        if (opfsSupportsReadWriteUnsafe) {
+          available.push(DatabaseImplementation.opfsWithExternalLocks);
+        }
       }
     };
 
@@ -388,7 +392,7 @@ export class DatabaseClient implements WebSqlite {
         connection = this.#connectionToDedicated!;
     }
 
-    let internalFileSystemImpl: "s" | "l" | "x" | "i" | "m";
+    let internalFileSystemImpl: "s" | "l" | "x" | "y" | "i" | "m";
     switch (implementation.storage) {
       case opfs:
         if (implementation === DatabaseImplementation.opfsAtomics) {
@@ -399,6 +403,10 @@ export class DatabaseClient implements WebSqlite {
           implementation === DatabaseImplementation.opfsWithExternalLocks
         ) {
           internalFileSystemImpl = "x";
+        } else if (
+          implementation === DatabaseImplementation.opfsWithExternalLocksWorkaround
+        ) {
+          internalFileSystemImpl = "y";
         } else {
           throw new Error("Unknown OPFS file system impl");
         }

--- a/sqlite3_web/extra/js-package/src/client.ts
+++ b/sqlite3_web/extra/js-package/src/client.ts
@@ -282,7 +282,6 @@ export class DatabaseClient implements WebSqlite {
       handleCompatibilityResult(result);
       const canUseOpfs = result.c;
       const canUseIndexedDb = result.d;
-      const supportsSharedArrayBuffers = result.e;
       const dedicatedWorkersCanNest = result.f;
       const opfsSupportsReadWriteUnsafe = result.g;
 
@@ -295,19 +294,12 @@ export class DatabaseClient implements WebSqlite {
       if (!opfsSupportsReadWriteUnsafe) {
         this.#missingFeatures.add("createSyncAccessHandleReadWriteUnsafe");
       }
-      if (!supportsSharedArrayBuffers) {
-        this.#missingFeatures.add("sharedArrayBuffers");
-      }
       if (!dedicatedWorkersCanNest) {
         this.#missingFeatures.add("dedicatedWorkersCanNest");
       }
 
       if (canUseOpfs) {
         available.push(DatabaseImplementation.opfsWithExternalLocksWorkaround);
-
-        if (supportsSharedArrayBuffers && dedicatedWorkersCanNest) {
-          available.push(DatabaseImplementation.opfsAtomics);
-        }
         if (opfsSupportsReadWriteUnsafe) {
           available.push(DatabaseImplementation.opfsWithExternalLocks);
         }
@@ -395,9 +387,7 @@ export class DatabaseClient implements WebSqlite {
     let internalFileSystemImpl: "s" | "l" | "x" | "y" | "i" | "m";
     switch (implementation.storage) {
       case opfs:
-        if (implementation === DatabaseImplementation.opfsAtomics) {
-          internalFileSystemImpl = "l";
-        } else if (implementation === DatabaseImplementation.opfsShared) {
+        if (implementation === DatabaseImplementation.opfsShared) {
           internalFileSystemImpl = "s";
         } else if (
           implementation === DatabaseImplementation.opfsWithExternalLocks

--- a/sqlite3_web/extra/js-package/src/generated_protocol.ts
+++ b/sqlite3_web/extra/js-package/src/generated_protocol.ts
@@ -2,7 +2,6 @@
 import { WebEndpoint } from "./channel.js";
 export const typeOpenRequest = "open";
 export const typeConnectRequest = "connect";
-export const typeStartFileSystemServer = "startFileSystemServer";
 export const typeCustomRequest = "custom";
 export const typeFileSystemExistsQuery = "fileSystemExists";
 export const typeFileSystemFlushRequest = "fileSystemFlush";
@@ -33,7 +32,6 @@ export type Message =
   | Response
   | OpenRequest
   | ConnectRequest
-  | StartFileSystemServer
   | CustomRequest
   | FileSystemExistsQuery
   | FileSystemFlushRequest
@@ -113,12 +111,6 @@ export interface ConnectRequest {
   d: number /* int */ | null;
   // Dart name: type
   t: "connect";
-}
-export interface StartFileSystemServer {
-  // Dart name: options
-  a: unknown /* WorkerOptions */;
-  // Dart name: type
-  t: "startFileSystemServer";
 }
 export interface CustomRequest {
   // Dart name: payload
@@ -391,7 +383,6 @@ export function extractTransferrable(message: Message): Transferable[] {
 export function dispatchMessage<T>(
   msg: Message,
   cb: {
-    _internal_whenStartFileSystemServer: (message: StartFileSystemServer) => T;
     _internal_whenAbortRequest: (message: AbortRequest) => T;
     _internal_whenNotification: (message: Notification) => T;
     _internal_whenResponse: (message: Response) => T;
@@ -399,10 +390,6 @@ export function dispatchMessage<T>(
   },
 ): T {
   switch (msg.t) {
-    case typeStartFileSystemServer:
-      return cb._internal_whenStartFileSystemServer(
-        msg as StartFileSystemServer,
-      );
     case typeAbortRequest:
       return cb._internal_whenAbortRequest(msg as AbortRequest);
     case typeUpdateNotification:

--- a/sqlite3_web/lib/src/channel.dart
+++ b/sqlite3_web/lib/src/channel.dart
@@ -158,8 +158,6 @@ abstract base class ProtocolChannel extends RequestHandler {
           token.abort();
         }
       },
-      whenStartFileSystemServer: (_) =>
-          throw StateError('Should only be a top-level message'),
     );
   }
 

--- a/sqlite3_web/lib/src/client.dart
+++ b/sqlite3_web/lib/src/client.dart
@@ -598,20 +598,23 @@ final class DatabaseClient implements WebSqlite {
         _missingFeatures.add(MissingBrowserFeature.dedicatedWorkersCanNest);
       }
 
-      // For the OPFS storage layer in dedicated workers, we're spawning two
-      // nested workers communicating through a synchronous channel created by
-      // Atomics and SharedArrayBuffers.
-      if (result.canUseOpfs &&
-          result.supportsSharedArrayBuffers &&
-          result.dedicatedWorkersCanNest) {
-        available.add(DatabaseImplementation.opfsAtomics);
-      }
+      if (result.canUseOpfs) {
+        // For the OPFS storage layer in dedicated workers, we're spawning two
+        // nested workers communicating through a synchronous channel created by
+        // Atomics and SharedArrayBuffers.
+        if (result.supportsSharedArrayBuffers &&
+            result.dedicatedWorkersCanNest) {
+          available.add(DatabaseImplementation.opfsAtomics);
+        }
 
-      // Another option is to use a single worker opening files with
-      // readwrite-unsafe. That allows opening the database in multiple tabs,
-      // but we'd then have to use weblocks to coordinate access.
-      if (result.canUseOpfs && result.opfsSupportsReadWriteUnsafe) {
-        available.add(DatabaseImplementation.opfsWithExternalLocks);
+        // Another option is to use a single worker opening files with
+        // readwrite-unsafe. That allows opening the database in multiple tabs,
+        // but we'd then have to use weblocks to coordinate access.
+        if (result.opfsSupportsReadWriteUnsafe) {
+          available.add(DatabaseImplementation.opfsWithExternalLocks);
+        }
+
+        available.add(DatabaseImplementation.opfsWithExternalLocksWorkaround);
       }
     }
 
@@ -801,12 +804,11 @@ extension on DatabaseImplementation {
   FileSystemImplementation resolveToVfs() {
     return switch (storage) {
       StorageMode.opfs => switch (this) {
-        DatabaseImplementation.opfsAtomics =>
-          FileSystemImplementation.opfsAtomics,
-        DatabaseImplementation.opfsShared =>
-          FileSystemImplementation.opfsShared,
-        DatabaseImplementation.opfsWithExternalLocks =>
-          FileSystemImplementation.opfsExternalLocks,
+        .opfsAtomics => FileSystemImplementation.opfsAtomics,
+        .opfsShared => FileSystemImplementation.opfsShared,
+        .opfsWithExternalLocks => FileSystemImplementation.opfsExternalLocks,
+        .opfsWithExternalLocksWorkaround =>
+          FileSystemImplementation.opfsExternalLocksWorkaround,
         _ => throw AssertionError('Unknown OPFS implementation'),
       },
       StorageMode.indexedDb => FileSystemImplementation.indexedDb,

--- a/sqlite3_web/lib/src/client.dart
+++ b/sqlite3_web/lib/src/client.dart
@@ -591,22 +591,8 @@ final class DatabaseClient implements WebSqlite {
           MissingBrowserFeature.createSyncAccessHandleReadWriteUnsafe,
         );
       }
-      if (!result.supportsSharedArrayBuffers) {
-        _missingFeatures.add(MissingBrowserFeature.sharedArrayBuffers);
-      }
-      if (!result.dedicatedWorkersCanNest) {
-        _missingFeatures.add(MissingBrowserFeature.dedicatedWorkersCanNest);
-      }
 
       if (result.canUseOpfs) {
-        // For the OPFS storage layer in dedicated workers, we're spawning two
-        // nested workers communicating through a synchronous channel created by
-        // Atomics and SharedArrayBuffers.
-        if (result.supportsSharedArrayBuffers &&
-            result.dedicatedWorkersCanNest) {
-          available.add(DatabaseImplementation.opfsAtomics);
-        }
-
         // Another option is to use a single worker opening files with
         // readwrite-unsafe. That allows opening the database in multiple tabs,
         // but we'd then have to use weblocks to coordinate access.
@@ -804,7 +790,6 @@ extension on DatabaseImplementation {
   FileSystemImplementation resolveToVfs() {
     return switch (storage) {
       StorageMode.opfs => switch (this) {
-        .opfsAtomics => FileSystemImplementation.opfsAtomics,
         .opfsShared => FileSystemImplementation.opfsShared,
         .opfsWithExternalLocks => FileSystemImplementation.opfsExternalLocks,
         .opfsWithExternalLocksWorkaround =>

--- a/sqlite3_web/lib/src/external_locks_vfs.dart
+++ b/sqlite3_web/lib/src/external_locks_vfs.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:sqlite3/wasm.dart';
+import 'package:web/web.dart' as web;
+
+/// A [SimpleOpfsFileSystem] managed with external navigator locks.
+///
+/// Normally, only a single file handle can be opened for OPFS files, and the
+/// process of opening these files is asynchronous. To allow multiple tabs to
+/// access the same database, it is wrapped in external locks:
+///
+///  1. On browsers that support it, we use the `readwrite-unsafe` open mode to
+///     pre-open the VFS. We still have to use navigator locks to avoid races.
+///  2. On other browsers, we open the VFS when a tab wants to use the database
+///     and close it afterwards. This is less efficient, but still works.
+///
+/// The web worker is responsible for calling [markHasExclusiveAccess] before
+/// using the database in any way. In this package, databases are only accesssed
+/// asynchronously, so we can check these external locks first.
+///
+/// This is a generalization of [WasmVfs] that doesn't require COOP + COEP
+/// headers and has similar performance characteristics. On browsers with
+/// `readwrite-unsafe` support, it's substantially faster.
+final class ExternalLocksState {
+  final SimpleOpfsFileSystem fs;
+
+  /// The directory in which the database file and journal are stored.
+  final web.FileSystemDirectoryHandle _directory;
+
+  final bool readWriteUnsafe;
+  bool _hasExclusiveAccess = false;
+
+  ExternalLocksState._(this.fs, this._directory, this.readWriteUnsafe);
+
+  static Future<ExternalLocksState> open({
+    required String path,
+    required String vfsName,
+    required bool readWriteUnsafe,
+  }) async {
+    final directory = await SimpleOpfsFileSystem.resolveDirectory(path);
+    final vfs = SimpleOpfsFileSystem(vfsName: vfsName);
+    if (readWriteUnsafe) {
+      // We can open this already
+      // ignore: experimental_member_use
+      await vfs.open(directory, readWriteUnsafe: true);
+    }
+
+    return ExternalLocksState._(vfs, directory, readWriteUnsafe);
+  }
+
+  Future<void> markHasExclusiveAccess() async {
+    assert(!_hasExclusiveAccess);
+    if (!readWriteUnsafe) {
+      // ignore: experimental_member_use
+      await fs.open(_directory);
+    }
+
+    _hasExclusiveAccess = true;
+  }
+
+  Future<void> releaseExclusiveAccess() async {
+    assert(_hasExclusiveAccess);
+    if (!readWriteUnsafe) {
+      fs.close();
+    }
+    _hasExclusiveAccess = false;
+  }
+}

--- a/sqlite3_web/lib/src/locks.dart
+++ b/sqlite3_web/lib/src/locks.dart
@@ -112,8 +112,8 @@ final class DatabaseLocks {
       try {
         return await criticalSection();
       } finally {
-        held.release();
         if (attached != null) await attached.releaseExclusiveAccess();
+        held.release();
       }
     }
 

--- a/sqlite3_web/lib/src/locks.dart
+++ b/sqlite3_web/lib/src/locks.dart
@@ -5,6 +5,7 @@ import 'dart:js_interop_unsafe';
 
 import 'package:web/web.dart';
 
+import 'external_locks_vfs.dart';
 import 'types.dart';
 
 @JS('navigator')
@@ -72,6 +73,10 @@ final class DatabaseLocks {
   /// is necessary to manage exclusive access.
   final bool needsInterContextLocks;
 
+  /// If these locks are for a datbase backed by a VFS that needs to be locked
+  /// and unlocked as well, a reference to that VFS.
+  ExternalLocksState? _attachedVfs;
+
   DatabaseLocks(this.lockName, this.needsInterContextLocks);
 
   /// Returns whether a synchronous block could run immediately.
@@ -84,6 +89,12 @@ final class DatabaseLocks {
     return !needsInterContextLocks && !_dartMutex._inCriticalSection;
   }
 
+  void attachVfs(ExternalLocksState state) {
+    assert(_attachedVfs == null);
+    assert(needsInterContextLocks);
+    _attachedVfs = state;
+  }
+
   Future<T> lock<T>(
     FutureOr<T> Function() criticalSection,
     AbortSignal? abortSignal,
@@ -93,7 +104,17 @@ final class DatabaseLocks {
         lockName,
         abortSignal: abortSignal,
       );
-      return Future(criticalSection).whenComplete(held.release);
+      final attached = _attachedVfs;
+      if (attached != null) {
+        await attached.markHasExclusiveAccess();
+      }
+
+      try {
+        return await criticalSection();
+      } finally {
+        held.release();
+        if (attached != null) await attached.releaseExclusiveAccess();
+      }
     }
 
     return _dartMutex.withCriticalSection(criticalSection, abort: abortSignal);

--- a/sqlite3_web/lib/src/locks.dart
+++ b/sqlite3_web/lib/src/locks.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 import 'dart:js_interop';
 import 'dart:js_interop_unsafe';
 
+import 'package:meta/meta.dart';
 import 'package:web/web.dart';
 
 import 'external_locks_vfs.dart';
@@ -11,30 +12,39 @@ import 'types.dart';
 @JS('navigator')
 external Navigator get _navigator;
 
-class WebLocks {
-  final LockManager _lockManager;
-
-  WebLocks._(this._lockManager);
-
-  Future<HeldLock> request(String name, {AbortSignal? abortSignal}) {
+extension type WebLocks._(LockManager raw) {
+  Future<HeldLock> request(
+    String name, {
+    AbortSignal? abortSignal,
+    bool steal = false,
+    void Function()? onStolen,
+  }) {
     final gotLock = Completer<HeldLock>.sync();
+    HeldLock? resolvedLock;
 
     JSPromise callback(JSAny lock) {
       final completer = Completer<void>.sync();
-      gotLock.complete(HeldLock._(completer));
+      gotLock.complete(resolvedLock = HeldLock._(completer));
       return completer.future.toJS;
     }
 
-    final options = LockOptions();
+    final options = LockOptions(steal: steal);
     if (abortSignal case final signal?) {
       options.signal = signal;
     }
 
-    _lockManager.request(name, options, callback.toJS).toDart.onError((e, s) {
+    raw.request(name, options, callback.toJS).toDart.onError((e, s) {
       final domError = e as DOMException;
+      final isAbortError = domError.name == 'AbortError';
 
-      if (!gotLock.isCompleted) {
-        if (domError.name == 'AbortError') {
+      if (resolvedLock case final resolved?) {
+        if (!resolved._completer.isCompleted) {
+          // The callback was invoked, but isn't completed yet. That can only
+          // mean that the lock has been stolen from another tab.
+          onStolen?.call();
+        }
+      } else {
+        if (isAbortError) {
           gotLock.completeError(AbortException(), s);
         } else {
           gotLock.completeError(domError, s);
@@ -60,8 +70,24 @@ class HeldLock {
   void release() => _completer.complete();
 }
 
+/// Locks to manage exclusive access to databases, across tabs if necessary.
+///
+/// This is especially relevant for OPFS databases, where we can't have more
+/// than one tab operate on the database at the same time.
+/// Additionally, we want to avoid lock overhead for single-tab apps. So, the
+/// lock protocol is as follows:
+///
+///   1. Obtain an outer lock, stealing it if necessary.
+///   2. Obtain an inner lock.
+///   3. Run the exclusive operation.
+///   4. Wait for another tab to steal the outer lock from us.
+///   5. Return the inner lock.
 final class DatabaseLocks {
-  final String lockName;
+  @visibleForTesting
+  final String outerLockName;
+  @visibleForTesting
+  final String innerLockName;
+
   final Mutex _dartMutex = Mutex();
 
   /// Whether this database needs a lock implementation providing exclusive
@@ -77,7 +103,10 @@ final class DatabaseLocks {
   /// and unlocked as well, a reference to that VFS.
   ExternalLocksState? _attachedVfs;
 
-  DatabaseLocks(this.lockName, this.needsInterContextLocks);
+  (HeldLock, HeldLock)? _heldNavigatorLocks;
+
+  DatabaseLocks(this.innerLockName, this.needsInterContextLocks)
+    : outerLockName = '$innerLockName-outer';
 
   /// Returns whether a synchronous block could run immediately.
   ///
@@ -86,7 +115,40 @@ final class DatabaseLocks {
   /// synchronously, no concurrency is possible and we don't need to explicitly
   /// update the lock's state.
   bool get canRunSynchronousBlockDirectly {
-    return !needsInterContextLocks && !_dartMutex._inCriticalSection;
+    if (_dartMutex._inCriticalSection) return false;
+
+    // We have no concurrent runner on the local mutex, so we can run a
+    // synchronous block if concurrency from other tabs is not a concern or if
+    // we currently hold an exclusive navigator lock (since we'd only return it
+    // asynchronously, after a synchronous block ran).
+    return !needsInterContextLocks || _heldNavigatorLocks != null;
+  }
+
+  Future<void> _acquireNavigatorLocks(AbortSignal? abortSignal) async {
+    assert(_heldNavigatorLocks == null);
+    final locks = WebLocks.instance!;
+    HeldLock? outer, inner;
+
+    try {
+      // 1. Request the outer lock, stealing it from another tab if necessary.
+      outer = await locks.request(
+        outerLockName,
+        steal: true,
+        onStolen: _handleOuterLockStolen,
+        // Not passing an abort signal here, those aren't supported with steal.
+      );
+
+      // 2. Obtain the inner lock.
+      inner = await locks.request(innerLockName, abortSignal: abortSignal);
+
+      await _attachedVfs?.markHasExclusiveAccess();
+      _heldNavigatorLocks = (outer, inner);
+    } on Object {
+      // Failed to acquire some locks, ensure they're all released.
+      outer?.release();
+      inner?.release();
+      rethrow;
+    }
   }
 
   void attachVfs(ExternalLocksState state) {
@@ -95,29 +157,43 @@ final class DatabaseLocks {
     _attachedVfs = state;
   }
 
+  void _handleOuterLockStolen() {
+    // Step 4 and 5.
+    releaseNavigatorLocks();
+  }
+
   Future<T> lock<T>(
     FutureOr<T> Function() criticalSection,
     AbortSignal? abortSignal,
-  ) async {
-    if (needsInterContextLocks) {
-      final held = await WebLocks.instance!.request(
-        lockName,
-        abortSignal: abortSignal,
-      );
-      final attached = _attachedVfs;
-      if (attached != null) {
-        await attached.markHasExclusiveAccess();
+  ) {
+    // Request the local mutex first. This is cheap, and allows
+    // _withNavigatorLocks to assume exclusive access to inner state.
+    return _dartMutex.withCriticalSection(abort: abortSignal, () {
+      if (!needsInterContextLocks || _heldNavigatorLocks != null) {
+        // Navigator locks not necessary or already held, run critical section
+        // immediately.
+        return criticalSection();
       }
 
-      try {
-        return await criticalSection();
-      } finally {
-        if (attached != null) await attached.releaseExclusiveAccess();
-        held.release();
-      }
-    }
+      return _acquireNavigatorLocks(abortSignal).then((_) {
+        // Step 3: Run the exclusive operation.
+        return criticalSection();
+        // Note: Step 4 and 5 run when the outer lock gets stolen from us, a
+        // callback reacting to that would have been installed at this point.
+      });
+    });
+  }
 
-    return _dartMutex.withCriticalSection(criticalSection, abort: abortSignal);
+  Future<void> releaseNavigatorLocks() {
+    return _dartMutex.withCriticalSection(() {
+      if (_heldNavigatorLocks case (final outer, final inner)?) {
+        _attachedVfs?.releaseExclusiveAccess();
+
+        outer.release();
+        inner.release();
+        _heldNavigatorLocks = null;
+      }
+    });
   }
 }
 

--- a/sqlite3_web/lib/src/protocol/compatibility_result.dart
+++ b/sqlite3_web/lib/src/protocol/compatibility_result.dart
@@ -34,28 +34,12 @@ final class CompatibilityResult {
   /// On some browsers, IndexedDB is not available in private/incognito tabs.
   final bool canUseIndexedDb;
 
-  /// Whether dedicated workers can use shared array buffers and the atomics
-  /// API.
-  ///
-  /// This is required for the synchronous channel used to host an OPFS
-  /// filesystem between threads. However, it is only available when the page is
-  /// served with special headers for security purposes.
-  final bool supportsSharedArrayBuffers;
-
-  /// Whether dedicated workers can spawn their own dedicated workers.
-  ///
-  /// We need two dedicated workers with a synchronous channel between them to
-  /// host an OPFS filesystem.
-  final bool dedicatedWorkersCanNest;
-
   CompatibilityResult({
     required this.existingDatabases,
     required this.sharedCanSpawnDedicated,
     required this.canUseOpfs,
     required this.opfsSupportsReadWriteUnsafe,
     required this.canUseIndexedDb,
-    required this.supportsSharedArrayBuffers,
-    required this.dedicatedWorkersCanNest,
   });
 
   factory CompatibilityResult.fromJS(JSObject result) {
@@ -74,8 +58,6 @@ final class CompatibilityResult {
       sharedCanSpawnDedicated: (result['b'] as JSBoolean).toDart,
       canUseOpfs: (result['c'] as JSBoolean).toDart,
       canUseIndexedDb: (result['d'] as JSBoolean).toDart,
-      supportsSharedArrayBuffers: (result['e'] as JSBoolean).toDart,
-      dedicatedWorkersCanNest: (result['f'] as JSBoolean).toDart,
       opfsSupportsReadWriteUnsafe: (result['g'] as JSBoolean).toDart,
     );
   }
@@ -93,8 +75,10 @@ final class CompatibilityResult {
       ..['b'] = sharedCanSpawnDedicated.toJS
       ..['c'] = canUseOpfs.toJS
       ..['d'] = canUseIndexedDb.toJS
-      ..['e'] = supportsSharedArrayBuffers.toJS
-      ..['f'] = dedicatedWorkersCanNest.toJS
+      // In old versions: supportsSharedArrayBuffers
+      ..['e'] = false.toJS
+      // In old versions: dedicatedWorkersCanNest
+      ..['f'] = false.toJS
       ..['g'] = opfsSupportsReadWriteUnsafe.toJS;
   }
 }

--- a/sqlite3_web/lib/src/protocol/helper.g.dart
+++ b/sqlite3_web/lib/src/protocol/helper.g.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'dart:js_interop';
 
 import 'package:web/web.dart' show AbortSignal;
-import 'package:sqlite3/wasm.dart' show WorkerOptions;
 
 import '../channel.dart';
 import 'messages.dart';
@@ -11,7 +10,6 @@ import 'messages.dart';
 enum MessageType<T extends Message> {
   open<OpenRequest>(),
   connect<ConnectRequest>(),
-  startFileSystemServer<StartFileSystemServer>(),
   custom<CustomRequest>(),
   fileSystemExists<FileSystemExistsQuery>(),
   fileSystemFlush<FileSystemFlushRequest>(),
@@ -244,23 +242,6 @@ ConnectRequest newConnectRequest({
     requestId: requestId,
     databaseId: databaseId,
     type: 'connect',
-  );
-}
-
-@anonymous
-extension type _StartFileSystemServer._(StartFileSystemServer _)
-    implements StartFileSystemServer {
-  external factory _StartFileSystemServer({
-    @JS('a') required WorkerOptions options,
-    @JS('t') required String type,
-  });
-}
-StartFileSystemServer newStartFileSystemServer({
-  required WorkerOptions options,
-}) {
-  return _StartFileSystemServer(
-    options: options,
-    type: 'startFileSystemServer',
   );
 }
 
@@ -810,15 +791,12 @@ JSArray<JSAny> extractTransferrable(Message message) {
 
 T dispatchMessage<T>(
   Message msg, {
-  required T Function(StartFileSystemServer) whenStartFileSystemServer,
   required T Function(AbortRequest) whenAbortRequest,
   required T Function(Notification) whenNotification,
   required T Function(Response) whenResponse,
   required T Function(Request) whenRequest,
 }) {
   switch (msg.type) {
-    case 'startFileSystemServer':
-      return whenStartFileSystemServer(msg as StartFileSystemServer);
     case 'abort':
       return whenAbortRequest(msg as AbortRequest);
     case 'notifyUpdate':

--- a/sqlite3_web/lib/src/protocol/messages.dart
+++ b/sqlite3_web/lib/src/protocol/messages.dart
@@ -1,7 +1,6 @@
 import 'dart:js_interop';
 import 'dart:typed_data';
 
-import 'package:sqlite3/wasm.dart';
 // ignore: implementation_imports
 import 'package:sqlite3/src/wasm/js_interop/core.dart';
 // ignore: implementation_imports
@@ -45,7 +44,6 @@ extension type Response._(JSObject _) implements Message {
 
 enum FileSystemImplementation {
   opfsShared('s'),
-  opfsAtomics('l'),
   opfsExternalLocks('x'),
 
   /// Like [opfsExternalLocks], but using a workaround based on re-opening OFPS
@@ -61,12 +59,7 @@ enum FileSystemImplementation {
   JSString get toJS => jsRepresentation.toJS;
 
   bool get needsExternalLocks =>
-      // Technically, opfsAtomics doesn't need external locks around each
-      // database access. We just do this to avoid contention in the underlying
-      // VFS.
-      this == opfsAtomics ||
-      this == opfsExternalLocks ||
-      this == opfsExternalLocksWorkaround;
+      this == opfsExternalLocks || this == opfsExternalLocksWorkaround;
 
   static FileSystemImplementation fromJS(JSString js) {
     final toDart = js.toDart;
@@ -114,12 +107,6 @@ extension type ConnectRequest._(JSObject _) implements Request {
   @JS(_UniqueFieldNames.responseData)
   @transfer
   external WebEndpoint endpoint;
-}
-
-@MessageTypeName('startFileSystemServer')
-extension type StartFileSystemServer._(JSObject _) implements Message {
-  @JS(_UniqueFieldNames.additionalData)
-  external WorkerOptions options;
 }
 
 /// Allows users of this package to implement their own RPC calls handled by

--- a/sqlite3_web/lib/src/protocol/messages.dart
+++ b/sqlite3_web/lib/src/protocol/messages.dart
@@ -47,6 +47,10 @@ enum FileSystemImplementation {
   opfsShared('s'),
   opfsAtomics('l'),
   opfsExternalLocks('x'),
+
+  /// Like [opfsExternalLocks], but using a workaround based on re-opening OFPS
+  /// file handles instead of `readwrite-unsafe`.
+  opfsExternalLocksWorkaround('y'),
   indexedDb('i'),
   inMemory('m');
 
@@ -60,7 +64,9 @@ enum FileSystemImplementation {
       // Technically, opfsAtomics doesn't need external locks around each
       // database access. We just do this to avoid contention in the underlying
       // VFS.
-      this == opfsAtomics || this == opfsExternalLocks;
+      this == opfsAtomics ||
+      this == opfsExternalLocks ||
+      this == opfsExternalLocksWorkaround;
 
   static FileSystemImplementation fromJS(JSString js) {
     final toDart = js.toDart;

--- a/sqlite3_web/lib/src/types.dart
+++ b/sqlite3_web/lib/src/types.dart
@@ -72,6 +72,13 @@ enum DatabaseImplementation {
   /// memory and atomics.
   opfsAtomics(StorageMode.opfs, AccessMode.throughDedicatedWorker),
 
+  /// A variant of [opfsWithExternalLocks] that works without the non-standard
+  /// `readwrite-unsafe` option (e.g. in Firefox and Safari).
+  opfsWithExternalLocksWorkaround(
+    StorageMode.opfs,
+    AccessMode.throughDedicatedWorker,
+  ),
+
   /// Open a synchronous database stored in OPFS.
   ///
   /// This works by letting a shared worker spawn a dedicated worker. This is

--- a/sqlite3_web/lib/src/types.dart
+++ b/sqlite3_web/lib/src/types.dart
@@ -67,17 +67,17 @@ enum DatabaseImplementation {
   /// database concurrently.
   opfsWithExternalLocks(StorageMode.opfs, AccessMode.throughDedicatedWorker),
 
-  /// Open an asynchronous database stored in OPFS. It is "syncified" by using
-  /// a pair of two dedicated workers implementing an RPC channel over shared
-  /// memory and atomics.
-  opfsAtomics(StorageMode.opfs, AccessMode.throughDedicatedWorker),
-
   /// A variant of [opfsWithExternalLocks] that works without the non-standard
   /// `readwrite-unsafe` option (e.g. in Firefox and Safari).
   opfsWithExternalLocksWorkaround(
     StorageMode.opfs,
     AccessMode.throughDedicatedWorker,
   ),
+
+  /// Open an asynchronous database stored in OPFS. It is "syncified" by using
+  /// a pair of two dedicated workers implementing an RPC channel over shared
+  /// memory and atomics.
+  opfsAtomics(StorageMode.opfs, AccessMode.throughDedicatedWorker),
 
   /// Open a synchronous database stored in OPFS.
   ///

--- a/sqlite3_web/lib/src/types.dart
+++ b/sqlite3_web/lib/src/types.dart
@@ -77,6 +77,10 @@ enum DatabaseImplementation {
   /// Open an asynchronous database stored in OPFS. It is "syncified" by using
   /// a pair of two dedicated workers implementing an RPC channel over shared
   /// memory and atomics.
+  @Deprecated(
+    'opfsWithExternalLocks and opfsWithExternalLocksWorkaround are supported '
+    'by all browsers, those are substantially simpler and faster.',
+  )
   opfsAtomics(StorageMode.opfs, AccessMode.throughDedicatedWorker),
 
   /// Open a synchronous database stored in OPFS.
@@ -225,6 +229,10 @@ enum MissingBrowserFeature {
   ///
   /// To enable this feature in most browsers, you need to serve your app with
   /// two [special headers](https://web.dev/coop-coep/).
+  @Deprecated(
+    'The VFS relying on this feature will be removed in a future version of '
+    'this package.',
+  )
   sharedArrayBuffers,
 }
 

--- a/sqlite3_web/lib/src/types.dart
+++ b/sqlite3_web/lib/src/types.dart
@@ -23,8 +23,8 @@ enum FileType {
 ///  - [opfsShared]: Only available on Firefox, but very efficient.
 ///  - [opfsWithExternalLocks]: Only available on recent Chrome versions, also
 ///    quite efficient.
-///  - [opfsAtomics]: Only available when using COEP and COOP headers, but also
-///    reasonably efficient and supported across browsers.
+///  - [opfsWithExternalLocksWorkaround]: A design similar to
+///    [opfsWithExternalLocks] that also works in Firefox and Safari.
 ///  - [indexedDbShared]: A less efficient IndexedDB-based implementation used
 ///    as a fallback on older Chrome versions.
 ///
@@ -73,15 +73,6 @@ enum DatabaseImplementation {
     StorageMode.opfs,
     AccessMode.throughDedicatedWorker,
   ),
-
-  /// Open an asynchronous database stored in OPFS. It is "syncified" by using
-  /// a pair of two dedicated workers implementing an RPC channel over shared
-  /// memory and atomics.
-  @Deprecated(
-    'opfsWithExternalLocks and opfsWithExternalLocksWorkaround are supported '
-    'by all browsers, those are substantially simpler and faster.',
-  )
-  opfsAtomics(StorageMode.opfs, AccessMode.throughDedicatedWorker),
 
   /// Open a synchronous database stored in OPFS.
   ///
@@ -209,10 +200,6 @@ enum MissingBrowserFeature {
   /// feature is only implemented by Firefox at the time of writing.
   dedicatedWorkersInSharedWorkers,
 
-  /// The browser doesn't allow dedicated workers to spawn their own dedicated
-  /// workers.
-  dedicatedWorkersCanNest,
-
   /// The browser does not support a synchronous version of the [File System API]
   ///
   /// [File System API]: https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API
@@ -224,16 +211,6 @@ enum MissingBrowserFeature {
 
   /// The browser does not support IndexedDB.
   indexedDb,
-
-  /// The browser does not support shared array buffers and `Atomics.wait`.
-  ///
-  /// To enable this feature in most browsers, you need to serve your app with
-  /// two [special headers](https://web.dev/coop-coep/).
-  @Deprecated(
-    'The VFS relying on this feature will be removed in a future version of '
-    'this package.',
-  )
-  sharedArrayBuffers,
 }
 
 /// The result of [WebSqlite.runFeatureDetection], describing which browsers

--- a/sqlite3_web/lib/src/worker.dart
+++ b/sqlite3_web/lib/src/worker.dart
@@ -650,10 +650,11 @@ final class DatabaseState {
               );
           closeHandler = simple.close;
         case FileSystemImplementation.opfsExternalLocks:
+        case FileSystemImplementation.opfsExternalLocksWorkaround:
           final state = await ExternalLocksState.open(
             path: pathForOpfs(name),
             vfsName: vfsName,
-            readWriteUnsafe: true,
+            readWriteUnsafe: mode == .opfsExternalLocks,
           );
           locks.attachVfs(state);
 

--- a/sqlite3_web/lib/src/worker.dart
+++ b/sqlite3_web/lib/src/worker.dart
@@ -722,6 +722,7 @@ final class DatabaseState {
     }
 
     await closeHandler?.call();
+    unawaited(locks.releaseNavigatorLocks());
   }
 }
 

--- a/sqlite3_web/lib/src/worker.dart
+++ b/sqlite3_web/lib/src/worker.dart
@@ -501,32 +501,34 @@ final class _ClientConnection extends ProtocolChannel
     final buffer = request.buffer;
 
     final vfs = await database.database.vfs;
-    final file = vfs
-        .xOpen(Sqlite3Filename(fsType.pathInVfs), SqlFlag.SQLITE_OPEN_CREATE)
-        .file;
+    return await database.useLock(null, abortSignal, () {
+      final file = vfs
+          .xOpen(Sqlite3Filename(fsType.pathInVfs), SqlFlag.SQLITE_OPEN_CREATE)
+          .file;
 
-    try {
-      if (buffer != null) {
-        final asDartBuffer = buffer.toDart;
-        file.xTruncate(asDartBuffer.lengthInBytes);
-        file.xWrite(asDartBuffer.asUint8List(), 0);
+      try {
+        if (buffer != null) {
+          final asDartBuffer = buffer.toDart;
+          file.xTruncate(asDartBuffer.lengthInBytes);
+          file.xWrite(asDartBuffer.asUint8List(), 0);
 
-        return newSimpleSuccessResponse(
-          response: null,
-          requestId: request.requestId,
-        );
-      } else {
-        final buffer = Uint8List(file.xFileSize());
-        file.xRead(buffer, 0);
+          return newSimpleSuccessResponse(
+            response: null,
+            requestId: request.requestId,
+          );
+        } else {
+          final buffer = Uint8List(file.xFileSize());
+          file.xRead(buffer, 0);
 
-        return newSimpleSuccessResponse(
-          response: buffer.buffer.toJS,
-          requestId: request.requestId,
-        );
+          return newSimpleSuccessResponse(
+            response: buffer.buffer.toJS,
+            requestId: request.requestId,
+          );
+        }
+      } finally {
+        file.xClose();
       }
-    } finally {
-      file.xClose();
-    }
+    });
   }
 
   @override
@@ -536,8 +538,12 @@ final class _ClientConnection extends ProtocolChannel
   ) async {
     final database = _requireDatabase(request);
     final vfs = await database.database.vfs;
-    final exists =
-        vfs.xAccess(FileType.values[request.fsType].pathInVfs, 0) == 1;
+
+    final exists = await database.useLock(
+      null,
+      abortSignal,
+      () => vfs.xAccess(FileType.values[request.fsType].pathInVfs, 0) == 1,
+    );
 
     return newSimpleSuccessResponse(
       response: exists.toJS,

--- a/sqlite3_web/lib/src/worker.dart
+++ b/sqlite3_web/lib/src/worker.dart
@@ -18,6 +18,7 @@ import 'package:sqlite3/src/wasm/js_interop/new_file_system_access.dart';
 
 import 'database.dart';
 import 'channel.dart';
+import 'external_locks_vfs.dart';
 import 'locks.dart';
 import 'protocol.dart';
 import 'shared.dart';
@@ -649,13 +650,15 @@ final class DatabaseState {
               );
           closeHandler = simple.close;
         case FileSystemImplementation.opfsExternalLocks:
-          final simple = _resolvedVfs =
-              await SimpleOpfsFileSystem.loadFromStorage(
-                pathForOpfs(name),
-                vfsName: vfsName,
-                readWriteUnsafe: true,
-              );
-          closeHandler = simple.close;
+          final state = await ExternalLocksState.open(
+            path: pathForOpfs(name),
+            vfsName: vfsName,
+            readWriteUnsafe: true,
+          );
+          locks.attachVfs(state);
+
+          final vfs = _resolvedVfs = state.fs;
+          closeHandler = vfs.close;
         case FileSystemImplementation.indexedDb:
           final idb = _resolvedVfs = await IndexedDbFileSystem.open(
             dbName: name,

--- a/sqlite3_web/lib/src/worker.dart
+++ b/sqlite3_web/lib/src/worker.dart
@@ -632,22 +632,6 @@ final class DatabaseState {
   Future<VirtualFileSystem> get vfs async {
     await (_openVfs ??= Future.sync(() async {
       switch (mode) {
-        case FileSystemImplementation.opfsAtomics:
-          final options = WasmVfs.createOptions(root: pathForOpfs(name));
-          final worker = runner._environment.connector.spawnDedicatedWorker()!;
-
-          newStartFileSystemServer(options: options).sendToWorker(worker);
-
-          // Wait for the server worker to report that it's ready
-          await EventStreamProviders.messageEvent
-              .forTarget(worker.targetForErrorEvents)
-              .first;
-
-          final wasmVfs = _resolvedVfs = WasmVfs(
-            workerOptions: options,
-            vfsName: vfsName,
-          );
-          closeHandler = wasmVfs.close;
         case FileSystemImplementation.opfsShared:
           final simple = _resolvedVfs =
               await SimpleOpfsFileSystem.loadFromStorage(
@@ -757,13 +741,6 @@ final class WorkerRunner {
       if (message.type == MessageType.connect.name) {
         final channel = (message as ConnectRequest).endpoint.connect();
         _accept(channel);
-      } else if (message.type == MessageType.startFileSystemServer.name) {
-        final worker = await VfsWorker.create(
-          (message as StartFileSystemServer).options,
-        );
-        // Inform the requester that the VFS is ready
-        (globalContext as DedicatedWorkerGlobalScope).postMessage(true.toJS);
-        await worker.start();
       } else if (isCompatibilityCheck(message.type)) {
         // A compatibility check message is sent to dedicated workers inside of
         // shared workers, we respond through the top-level port.
@@ -847,8 +824,6 @@ final class WorkerRunner {
         canUseOpfs: supportsOpfs,
         opfsSupportsReadWriteUnsafe: opfsSupportsReadWriteUnsafe,
         canUseIndexedDb: supportsIndexedDb,
-        supportsSharedArrayBuffers: globalContext.has('SharedArrayBuffer'),
-        dedicatedWorkersCanNest: globalContext.has('Worker'),
       );
     });
   }

--- a/sqlite3_web/test/client_test.dart
+++ b/sqlite3_web/test/client_test.dart
@@ -16,7 +16,6 @@ void main() {
       DatabaseImplementation.opfsShared,
       DatabaseImplementation.opfsWithExternalLocks,
       DatabaseImplementation.opfsWithExternalLocksWorkaround,
-      DatabaseImplementation.opfsAtomics,
       DatabaseImplementation.indexedDbShared,
       DatabaseImplementation.indexedDbUnsafeWorker,
       DatabaseImplementation.indexedDbUnsafeLocal,

--- a/sqlite3_web/test/client_test.dart
+++ b/sqlite3_web/test/client_test.dart
@@ -15,6 +15,7 @@ void main() {
     expect(all, [
       DatabaseImplementation.opfsShared,
       DatabaseImplementation.opfsWithExternalLocks,
+      DatabaseImplementation.opfsWithExternalLocksWorkaround,
       DatabaseImplementation.opfsAtomics,
       DatabaseImplementation.indexedDbShared,
       DatabaseImplementation.indexedDbUnsafeWorker,

--- a/sqlite3_web/test/integration_test.dart
+++ b/sqlite3_web/test/integration_test.dart
@@ -290,24 +290,5 @@ final class _TestConfiguration {
       expect(actualImplementation.storage, StorageMode.indexedDb);
       await driver.execute('INSERT INTO foo DEFAULT VALUES');
     });
-
-    test('can migrate from opfs-locks to simpler setup', () async {
-      await driver.openDatabase(implementation: .opfsAtomics);
-      await driver.execute('CREATE TABLE foo (bar TEXT);');
-      await driver.closeDatabase();
-
-      await driver.driver.refresh();
-      await driver.waitReady();
-
-      final features = await driver.probeImplementations();
-      expect(features.existing, [(StorageMode.opfs, 'database')]);
-
-      final actualImplementation = await driver.openDatabase(onlyOpenVfs: true);
-      expect(actualImplementation.storage, StorageMode.opfs);
-      expect(actualImplementation, isNot(DatabaseImplementation.opfsAtomics));
-      await driver.assertFile(true);
-
-      await driver.execute('INSERT INTO foo DEFAULT VALUES');
-    });
   }
 }

--- a/sqlite3_web/test/integration_test.dart
+++ b/sqlite3_web/test/integration_test.dart
@@ -290,5 +290,24 @@ final class _TestConfiguration {
       expect(actualImplementation.storage, StorageMode.indexedDb);
       await driver.execute('INSERT INTO foo DEFAULT VALUES');
     });
+
+    test('can migrate from opfs-locks to simpler setup', () async {
+      await driver.openDatabase(implementation: .opfsAtomics);
+      await driver.execute('CREATE TABLE foo (bar TEXT);');
+      await driver.closeDatabase();
+
+      await driver.driver.refresh();
+      await driver.waitReady();
+
+      final features = await driver.probeImplementations();
+      expect(features.existing, [(StorageMode.opfs, 'database')]);
+
+      final actualImplementation = await driver.openDatabase(onlyOpenVfs: true);
+      expect(actualImplementation.storage, StorageMode.opfs);
+      expect(actualImplementation, isNot(DatabaseImplementation.opfsAtomics));
+      await driver.assertFile(true);
+
+      await driver.execute('INSERT INTO foo DEFAULT VALUES');
+    });
   }
 }

--- a/sqlite3_web/test/lock_test.dart
+++ b/sqlite3_web/test/lock_test.dart
@@ -2,6 +2,8 @@
 library;
 
 import 'dart:async';
+import 'dart:js_interop';
+import 'dart:math';
 
 import 'package:sqlite3_web/src/locks.dart';
 import 'package:sqlite3_web/src/types.dart';
@@ -69,4 +71,73 @@ void main() {
       );
     });
   });
+
+  group('database locks', () {
+    test('without inter-context support', () async {
+      final locks = DatabaseLocks('foo', false);
+      expect(locks.canRunSynchronousBlockDirectly, isTrue);
+
+      await locks.lock(() async {
+        expect(locks.canRunSynchronousBlockDirectly, isFalse);
+      }, null);
+    });
+
+    test('keeps navigator locks after critical section', () async {
+      final name = _randomLockName();
+      final locks = DatabaseLocks(name, true);
+      await locks.lock(() async {}, null);
+
+      // Should keep the outer and inner lock locked at this point.
+      expect(await _queryHeldLocks(name), hasLength(2));
+
+      // Stealing the outer lock should release both locks.
+      final stolen = await WebLocks.instance!.request(
+        locks.outerLockName,
+        steal: true,
+      );
+      stolen.release();
+
+      await pumpEventQueue();
+      expect(await _queryHeldLocks(name), isEmpty);
+    });
+
+    test('can release navigator locks explicitly', () async {
+      final name = _randomLockName();
+      final locks = DatabaseLocks(name, true);
+      await locks.lock(() async {}, null);
+      expect(await _queryHeldLocks(name), hasLength(2));
+
+      await locks.releaseNavigatorLocks();
+      await pumpEventQueue();
+      expect(await _queryHeldLocks(name), hasLength(0));
+    });
+
+    test('can coordinate across multiple instances', () async {
+      final name = _randomLockName();
+      final a = DatabaseLocks(name, true);
+      final b = DatabaseLocks(name, true);
+
+      await a.lock(() async {}, null);
+      await b.lock(() async {}, null);
+    });
+  });
+}
+
+String _randomLockName() {
+  final buffer = StringBuffer();
+  final random = Random();
+
+  for (var i = 0; i < 16; i++) {
+    const charCodeSmallA = 97;
+    buffer.writeCharCode(charCodeSmallA + random.nextInt(26));
+  }
+
+  return buffer.toString();
+}
+
+Future<List<String>> _queryHeldLocks(String name) async {
+  final queried = await WebLocks.instance!.raw.query().toDart;
+  final held = queried.held.toDart;
+
+  return held.map((e) => e.name).where((e) => e.contains(name)).toList();
 }

--- a/sqlite3_web/tool/protocol_generator.dart
+++ b/sqlite3_web/tool/protocol_generator.dart
@@ -244,7 +244,6 @@ import 'dart:async';
 import 'dart:js_interop';
 
 import 'package:web/web.dart' show AbortSignal;
-import 'package:sqlite3/wasm.dart' show WorkerOptions;
 
 import '../channel.dart';
 import 'messages.dart';


### PR DESCRIPTION
We currently have three ways of using OPFS on the web:

1. In Chrome, by opening files with `readwrite-unsafe` in all tabs, and then using navigator locks to manage concurrency.
2. In Firefox, by opening the file system in a dedicated worker managed by a shared worker.
3. In all browsers, through an IPC channel using atomics to block on asynchronous operations.

This adds a fourth one, similar to the third but hopefully better in every way: In `sqlite3_web`, databases are only accessed through asynchronous methods. So, instead of opening files when SQLite asks us to (at which point we have to do it synchronously), we can open files in an async Dart method before we use SQLite at all!

This implements that method by:

1.  Allowing `SimpleOpfsFileSystem` to be closed and re-opened (preserving open virtual files with switched underlying file handles).
2. Adding `opfsWithExternalLocksWorkaround` as an implementation making the worker open file handles lazily and closing them once another tab needs them.
3. Instead of using the timeout-based heuristics from the original atomics VFS, this uses navigator locks requested with `steal: true` to let tabs notify other tabs that they need access to the database.

This allows using OPFS in all browsers without special headers, even in Safari. As long as only a single tab needs access to the database at a time, the new VFS should have the same decent performance as `readwrite-unsafe` or the one backed by the shared worker. So this is a nice improvement overall, and we should be able to get rid of the atomics-based VFS in a future release.