### PR TITLE
fix: use deterministic string for download cache dirname instead of Object.hash()

### DIFF
--- a/sqlite3/lib/src/hook/assets.dart
+++ b/sqlite3/lib/src/hook/assets.dart
@@ -106,7 +106,13 @@ final class PrebuiltSqliteLibrary {
   /// this library.
   ///
   /// There's a test asserting that this is unique for all valid values.
-  String get dirname => 'download-${hashCode.toRadixString(16)}';
+  ///
+  /// Uses a deterministic name so the download cache survives across separate
+  /// hook invocations (different Dart processes). Previously this used
+  /// [hashCode], but [Object.hash] is seeded per-isolate and produces
+  /// different values in every process, making the cache useless.
+  String get dirname =>
+      'download-${releaseTag}_${type.basename}_${os.name}_${architecture.name}';
 
   @override
   int get hashCode => Object.hash(

--- a/sqlite3/test/hook/assets_test.dart
+++ b/sqlite3/test/hook/assets_test.dart
@@ -1,16 +1,61 @@
 @TestOn('vm')
 library;
 
+import 'package:code_assets/code_assets.dart';
 import 'package:sqlite3/src/hook/assets.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('prebuilt libraries have no conflicting hash code', () {
-    // We join the hash code against the outputDirectoryShared of hooks, so
-    // there should be no collisions.
-    final hashes = <String>{};
+  test('prebuilt libraries have no conflicting dirname', () {
+    final names = <String>{};
     for (final target in PrebuiltSqliteLibrary.all) {
-      expect(hashes.add(target.dirname), isTrue);
+      expect(
+        names.add(target.dirname),
+        isTrue,
+        reason: 'dirname collision: ${target.dirname}',
+      );
     }
+  });
+
+  test('dirname is deterministic (string-based, not Object.hash)', () {
+    // If dirname were based on Object.hash(), these exact assertions would
+    // fail in a different Dart process because Object.hash() uses a
+    // per-isolate random seed. The fact that we can assert exact values
+    // proves dirname is now stable across processes.
+    final lib = PrebuiltSqliteLibrary(
+      os: TargetOperatingSystem.android,
+      architecture: Architecture.arm64,
+      type: LibraryType.sqlite3,
+    );
+    expect(lib.dirname, 'download-sqlite3-3.3.3_sqlite3_android_arm64');
+  });
+
+  test('hashCode is volatile but dirname is stable', () {
+    // Demonstrates the fix: hashCode (which uses Object.hash) changes
+    // across Dart processes, so it must NOT be used for persistent names.
+    // dirname uses deterministic string concatenation instead.
+    final a = PrebuiltSqliteLibrary(
+      os: TargetOperatingSystem.android,
+      architecture: Architecture.arm64,
+      type: LibraryType.sqlite3,
+    );
+    final b = PrebuiltSqliteLibrary(
+      os: TargetOperatingSystem.android,
+      architecture: Architecture.arm64,
+      type: LibraryType.sqlite3,
+    );
+
+    // Equal libraries must have equal hashCode (within same process).
+    expect(a, equals(b));
+    expect(a.hashCode, equals(b.hashCode));
+
+    // Different configurations produce different dirnames.
+    final c = PrebuiltSqliteLibrary(
+      os: TargetOperatingSystem.ios,
+      architecture: Architecture.arm64,
+      type: LibraryType.sqlite3,
+    );
+    expect(c.dirname, isNot(equals(a.dirname)));
+    expect(c.dirname, 'download-sqlite3-3.3.3_sqlite3_ios_arm64');
   });
 }


### PR DESCRIPTION
Each time when build, the hook dart will ignore the local cached lib binary and always attempt to download the lib binary from github. It fails to detect the local cached lib binary with wrong folder name generated from Object.hash(). 

After troubleshooting, I find that the root cause is Object.hash().

Object.hash() uses a per-isolate random seed in Dart, meaning the hashCode — and therefore the cache directory name — changes on every hook invocation. Previously downloaded binaries were never found on subsequent builds, forcing a re-download from GitHub each time.

Replace hashCode-based dirname with deterministic string concatenation of releaseTag, type basename, os name, and architecture name. This makes the cache directory name stable across Dart processes.

Example: download-sqlite3-3.3.3_sqlite3_android_arm64