### PR TITLE
Resolve relative paths in additional_includes and additional_lib_directories

### DIFF
--- a/sqlite3/lib/src/hook/compile/description.dart
+++ b/sqlite3/lib/src/hook/compile/description.dart
@@ -17,6 +17,7 @@ import '../utils.dart';
 sealed class SqliteBinary {
   static SqliteBinary forBuild(BuildInput input) {
     final userDefines = input.userDefines;
+    final userDefinesBase = _userDefinesBase(input);
 
     PrecompiledFromGithubAssets fromGitHub(LibraryType type) {
       final pattern =
@@ -24,6 +25,20 @@ sealed class SqliteBinary {
           PrecompiledFromGithubAssets.defaultUrlPattern;
 
       return PrecompiledFromGithubAssets(type, urlPattern: pattern);
+    }
+
+    List<String> resolvedPaths(String key) {
+      final List<String> entries =
+          (userDefines[key] as List?)?.cast() ?? const [];
+      if (userDefinesBase == null) return entries;
+
+      return [
+        for (final entry in entries)
+          if (p.isAbsolute(entry))
+            entry
+          else
+            userDefinesBase.resolve(entry).toFilePath(),
+      ];
     }
 
     switch (userDefines['source']) {
@@ -58,13 +73,12 @@ sealed class SqliteBinary {
             userDefines,
             input.config.code.targetOS,
           ),
-          additionalIncludes:
-              (userDefines['additional_includes'] as List?)?.cast() ?? const [],
+          additionalIncludes: resolvedPaths('additional_includes'),
           additionalFlags:
               (userDefines['additional_flags'] as List?)?.cast() ?? const [],
-          additionalLibraryDirectories:
-              (userDefines['additional_lib_directories'] as List?)?.cast() ??
-              const [],
+          additionalLibraryDirectories: resolvedPaths(
+            'additional_lib_directories',
+          ),
           additionalLibraries:
               (userDefines['additional_libraries'] as List?)?.cast() ??
               const [],
@@ -77,6 +91,22 @@ sealed class SqliteBinary {
               'executable',
         );
     }
+  }
+
+  /// The `pubspec.yaml` the user-defines were read from.
+  ///
+  /// Relative paths are resolved against this file, matching what
+  /// [HookInputUserDefines.path] does for `path`. That method only resolves a
+  /// single string, so list-valued options need the base itself.
+  static Uri? _userDefinesBase(BuildInput input) {
+    final userDefines = input.json['user_defines'];
+    if (userDefines is! Map) return null;
+
+    final source = userDefines['workspace_pubspec'];
+    if (source is! Map) return null;
+
+    final basePath = source['base_path'];
+    return basePath is String ? Uri.file(basePath) : null;
   }
 }
 

--- a/sqlite3/test/hook/description_test.dart
+++ b/sqlite3/test/hook/description_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
+import 'package:path/path.dart' as p;
 import 'package:sqlite3/src/hook/asset_hashes.dart';
 import 'package:sqlite3/src/hook/compile/description.dart';
 import 'package:test/test.dart';
@@ -34,6 +35,45 @@ void main() {
           targetArchitecture: Architecture.arm64,
           targetOS: OS.windows,
           linkModePreference: LinkModePreference.dynamic,
+        ),
+      ],
+    );
+  });
+
+  test('resolves relative paths against the pubspec', () async {
+    await testBuildHook(
+      userDefines: PackageUserDefines(
+        workspacePubspec: PackageUserDefinesSource(
+          defines: {
+            'source': 'source',
+            'path': 'native/sqlite3.c',
+            'additional_includes': ['native/include', '/absolute/include'],
+            'additional_lib_directories': ['native/lib'],
+          },
+          basePath: Uri.file(p.join(d.sandbox, 'pubspec.yaml')),
+        ),
+      ),
+      mainMethod: (args) {
+        return build(args, (input, outputs) async {
+          final config = SqliteBinary.forBuild(input) as CompileSqlite;
+
+          expect(config.sourceFile, p.join(d.sandbox, 'native', 'sqlite3.c'));
+          expect(config.additionalIncludes, [
+            p.join(d.sandbox, 'native', 'include'),
+            '/absolute/include',
+          ]);
+          expect(config.additionalLibraryDirectories, [
+            p.join(d.sandbox, 'native', 'lib'),
+          ]);
+        });
+      },
+      check: (_, _) {},
+      extensions: [
+        CodeAssetExtension(
+          targetArchitecture: Architecture.arm64,
+          targetOS: OS.macOS,
+          linkModePreference: LinkModePreference.dynamic,
+          macOS: MacOSCodeConfig(targetVersion: 13),
         ),
       ],
     );


### PR DESCRIPTION
With `source: source`, `path` is resolved against the pubspec, but `additional_includes` and `additional_lib_directories` are passed through as-is. `native_toolchain_c` then resolves them against its build directory (`.dart_tool/hooks_runner/shared/sqlite3/build/<checksum>/`), so relative entries can never point at anything useful and only absolute paths work today.

This resolves both against the pubspec, matching `path`. Absolute entries pass through unchanged. Not breaking, since relative values are currently unusable.

The base is read from `input.json['user_defines']['workspace_pubspec']['base_path']` because `HookInputUserDefines.path()` only resolves a single string.

Test added to `test/hook/description_test.dart`.
