### PR TITLE
Add additional_sources for compiling extra C sources

### DIFF
--- a/sqlite3/doc/hook.md
+++ b/sqlite3/doc/hook.md
@@ -150,6 +150,7 @@ hooks:
 
 The build can be configured further with these additional options:
 
+- `additional_sources`: Additional C sources to compile, each as its own translation unit.
 - `additional_includes`: Additional include directories to add to the header search path.
 - `additional_flags`: Additional compiler options.
 - `additional_lib_directories` and `additional_libraries`: Additional libraries to link.

--- a/sqlite3/hook/build.dart
+++ b/sqlite3/hook/build.dart
@@ -37,6 +37,7 @@ void main(List<String> args) async {
       case CompileSqlite(
         :final sourceFile,
         :final defines,
+        :final additionalSources,
         :final additionalIncludes,
         :final additionalFlags,
         :final additionalLibraryDirectories,
@@ -70,7 +71,7 @@ ${usedSqliteSymbols.map((symbol) => '    $symbol;').join('\n')}
           name: 'sqlite3',
           packageName: 'sqlite3',
           assetName: name,
-          sources: [sourceFile],
+          sources: [sourceFile, ...additionalSources],
           includes: [p.dirname(sourceFile), ...additionalIncludes],
           defines: defines,
           flags: [

--- a/sqlite3/lib/src/hook/compile/description.dart
+++ b/sqlite3/lib/src/hook/compile/description.dart
@@ -17,6 +17,7 @@ import '../utils.dart';
 sealed class SqliteBinary {
   static SqliteBinary forBuild(BuildInput input) {
     final userDefines = input.userDefines;
+    final userDefinesBase = _userDefinesBase(input);
 
     PrecompiledFromGithubAssets fromGitHub(LibraryType type) {
       final pattern =
@@ -24,6 +25,20 @@ sealed class SqliteBinary {
           PrecompiledFromGithubAssets.defaultUrlPattern;
 
       return PrecompiledFromGithubAssets(type, urlPattern: pattern);
+    }
+
+    List<String> resolvedPaths(String key) {
+      final List<String> entries =
+          (userDefines[key] as List?)?.cast() ?? const [];
+      if (userDefinesBase == null) return entries;
+
+      return [
+        for (final entry in entries)
+          if (p.isAbsolute(entry))
+            entry
+          else
+            userDefinesBase.resolve(entry).toFilePath(),
+      ];
     }
 
     switch (userDefines['source']) {
@@ -58,13 +73,12 @@ sealed class SqliteBinary {
             userDefines,
             input.config.code.targetOS,
           ),
-          additionalIncludes:
-              (userDefines['additional_includes'] as List?)?.cast() ?? const [],
+          additionalIncludes: resolvedPaths('additional_includes'),
           additionalFlags:
               (userDefines['additional_flags'] as List?)?.cast() ?? const [],
-          additionalLibraryDirectories:
-              (userDefines['additional_lib_directories'] as List?)?.cast() ??
-              const [],
+          additionalLibraryDirectories: resolvedPaths(
+            'additional_lib_directories',
+          ),
           additionalLibraries:
               (userDefines['additional_libraries'] as List?)?.cast() ??
               const [],
@@ -77,6 +91,22 @@ sealed class SqliteBinary {
               'executable',
         );
     }
+  }
+
+  /// The `pubspec.yaml` the user-defines were read from.
+  ///
+  /// Relative paths are resolved against this file, matching what
+  /// [HookInputUserDefines.path] does for `path`. That method only resolves a
+  /// single string, so list-valued options need the base itself.
+  static Uri? _userDefinesBase(BuildInput input) {
+    final userDefines = input.json['user_defines'];
+    if (userDefines is! Map) return null;
+
+    final source = userDefines['workspace_pubspec'];
+    if (source is! Map) return null;
+
+    final basePath = source['base_path'];
+    return basePath is String ? Uri.file(basePath) : null;
   }
 }
 

--- a/sqlite3/lib/src/hook/compile/description.dart
+++ b/sqlite3/lib/src/hook/compile/description.dart
@@ -73,6 +73,7 @@ sealed class SqliteBinary {
             userDefines,
             input.config.code.targetOS,
           ),
+          additionalSources: resolvedPaths('additional_sources'),
           additionalIncludes: resolvedPaths('additional_includes'),
           additionalFlags:
               (userDefines['additional_flags'] as List?)?.cast() ?? const [],
@@ -349,6 +350,9 @@ final class CompileSqlite implements SqliteBinary {
   /// User-defines for the SQLite compilation.
   final CompilerDefines defines;
 
+  /// Additional sources to compile, each as its own translation unit.
+  final List<String> additionalSources;
+
   /// Additional header search paths.
   final List<String> additionalIncludes;
 
@@ -363,6 +367,7 @@ final class CompileSqlite implements SqliteBinary {
   CompileSqlite({
     required this.sourceFile,
     required this.defines,
+    required this.additionalSources,
     required this.additionalIncludes,
     required this.additionalFlags,
     required this.additionalLibraryDirectories,

--- a/sqlite3/test/hook/description_test.dart
+++ b/sqlite3/test/hook/description_test.dart
@@ -3,6 +3,7 @@ library;
 
 import 'package:code_assets/code_assets.dart';
 import 'package:hooks/hooks.dart';
+import 'package:path/path.dart' as p;
 import 'package:sqlite3/src/hook/asset_hashes.dart';
 import 'package:sqlite3/src/hook/compile/description.dart';
 import 'package:test/test.dart';
@@ -34,6 +35,45 @@ void main() {
           targetArchitecture: Architecture.arm64,
           targetOS: OS.windows,
           linkModePreference: LinkModePreference.dynamic,
+        ),
+      ],
+    );
+  });
+
+  test('resolves relative paths against the pubspec', () async {
+    await testBuildHook(
+      userDefines: PackageUserDefines(
+        workspacePubspec: PackageUserDefinesSource(
+          defines: {
+            'source': 'source',
+            'path': 'native/sqlite3.c',
+            'additional_includes': ['native/include', '/absolute/include'],
+            'additional_lib_directories': ['native/lib'],
+          },
+          basePath: Uri.file(p.join(d.sandbox, 'pubspec.yaml')),
+        ),
+      ),
+      mainMethod: (args) {
+        return build(args, (input, outputs) async {
+          final config = SqliteBinary.forBuild(input) as CompileSqlite;
+
+          expect(config.sourceFile, p.join(d.sandbox, 'native', 'sqlite3.c'));
+          expect(config.additionalIncludes, [
+            p.join(d.sandbox, 'native', 'include'),
+            '/absolute/include',
+          ]);
+          expect(config.additionalLibraryDirectories, [
+            p.join(d.sandbox, 'native', 'lib'),
+          ]);
+        });
+      },
+      check: (_, _) {},
+      extensions: [
+        CodeAssetExtension(
+          targetArchitecture: Architecture.arm64,
+          targetOS: OS.macOS,
+          linkModePreference: LinkModePreference.dynamic,
+          macOS: MacOSCodeConfig(targetVersion: 13),
         ),
       ],
     );

--- a/sqlite3/test/hook/description_test.dart
+++ b/sqlite3/test/hook/description_test.dart
@@ -47,6 +47,7 @@ void main() {
           defines: {
             'source': 'source',
             'path': 'native/sqlite3.c',
+            'additional_sources': ['native/extension.c'],
             'additional_includes': ['native/include', '/absolute/include'],
             'additional_lib_directories': ['native/lib'],
           },
@@ -58,6 +59,9 @@ void main() {
           final config = SqliteBinary.forBuild(input) as CompileSqlite;
 
           expect(config.sourceFile, p.join(d.sandbox, 'native', 'sqlite3.c'));
+          expect(config.additionalSources, [
+            p.join(d.sandbox, 'native', 'extension.c'),
+          ]);
           expect(config.additionalIncludes, [
             p.join(d.sandbox, 'native', 'include'),
             '/absolute/include',


### PR DESCRIPTION
Note: This PR builds upon #394

`source: source` compiles exactly one file, so combining SQLite with extensions that ship as C sources means concatenating them into one unit. That doesn't generally work: `vec1.c` and `sqlite3.c` both define `i8`, one as `char` and one as `signed char`, and C has no way to separate them within a unit.

`additional_sources` compiles each entry as its own unit, alongside `path`. `CBuilder.library` already takes a list, so this just forwards it. Paths are resolved like the other options.

Test added to `test/hook/description_test.dart`.