### PR TITLE
Avoid callbacks when opening connection pools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,7 +155,7 @@ jobs:
       working-directory: sqlite3_connection_pool
       run: |
         dart build cli --target test/pool_test.dart -o out
-        systemd-run --user --pty --property=MemoryDenyWriteExecute=yes ./out/bundle/bin/pool_test
+        systemd-run --user --pipe --wait --collect --property=MemoryDenyWriteExecute=yes --property=RuntimeMaxSec=10 ./out/bundle/bin/pool_test
         rm -rf out
 
     - name: Enable sqlite3mc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,6 +149,15 @@ jobs:
         dart run.dart --sanitizer=msan
       working-directory: native_tests/
 
+    # Regression test for https://github.com/simolus3/sqlite3.dart/issues/396
+    - name: Test sqlite3_connection_pool with MemoryDenyWriteExecute
+      if: runner.os == 'Linux'
+      working-directory: sqlite3_connection_pool
+      run: |
+        dart build cli --target test/pool_test.dart -o out
+        systemd-run --user --pty --property=MemoryDenyWriteExecute=yes ./out/bundle/bin/pool_test
+        rm -rf out
+
     - name: Enable sqlite3mc
       run: |
         dart run tool/hook_overrides.dart compiled-ciphers

--- a/sqlite3_connection_pool/lib/src/ffi.g.dart
+++ b/sqlite3_connection_pool/lib/src/ffi.g.dart
@@ -65,25 +65,14 @@ external ffi.Pointer<PoolRequest> pkg_sqlite3_connection_pool_obtain_exclusive(
     ffi.Pointer<ConnectionPool>,
     ffi.Int64,
     ffi.Int64,
+    ffi.Char,
   )
 >(isLeaf: true)
-external ffi.Pointer<PoolRequest> pkg_sqlite3_connection_pool_obtain_read(
+external ffi.Pointer<PoolRequest> pkg_sqlite3_connection_pool_obtain_single(
   ffi.Pointer<ConnectionPool> pool,
   int tag,
   int port,
-);
-
-@ffi.Native<
-  ffi.Pointer<PoolRequest> Function(
-    ffi.Pointer<ConnectionPool>,
-    ffi.Int64,
-    ffi.Int64,
-  )
->(isLeaf: true)
-external ffi.Pointer<PoolRequest> pkg_sqlite3_connection_pool_obtain_write(
-  ffi.Pointer<ConnectionPool> pool,
-  int tag,
-  int port,
+  int read,
 );
 
 @ffi.Native<

--- a/sqlite3_connection_pool/lib/src/ffi.g.dart
+++ b/sqlite3_connection_pool/lib/src/ffi.g.dart
@@ -29,6 +29,22 @@ external void pkg_sqlite3_connection_pool_close(
   ffi.Pointer<ConnectionPool> pool,
 );
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<UninitializedPool>)>()
+external void pkg_sqlite3_connection_pool_close_uninitialized(
+  ffi.Pointer<UninitializedPool> uninitialized,
+);
+
+@ffi.Native<
+  ffi.Pointer<ConnectionPool> Function(
+    ffi.Pointer<UninitializedPool>,
+    ffi.Pointer<InitializedPool>,
+  )
+>()
+external ffi.Pointer<ConnectionPool> pkg_sqlite3_connection_pool_initialize(
+  ffi.Pointer<UninitializedPool> uninitialized,
+  ffi.Pointer<InitializedPool> pool,
+);
+
 @ffi.Native<ffi.Void Function(ffi.Pointer<PoolRequest>)>()
 external void pkg_sqlite3_connection_pool_notify_updates(
   ffi.Pointer<PoolRequest> request,
@@ -76,17 +92,18 @@ external ffi.Pointer<PoolRequest> pkg_sqlite3_connection_pool_obtain_single(
 );
 
 @ffi.Native<
-  ffi.Pointer<ConnectionPool> Function(
+  ffi.Void Function(
     ffi.Pointer<ffi.Uint8>,
     ffi.UintPtr,
-    ffi.Pointer<ffi.NativeFunction<ffi.Pointer<InitializedPool> Function()>>,
+    ffi.Pointer<ffi.Pointer<UninitializedPool>>,
+    ffi.Pointer<ffi.Pointer<ConnectionPool>>,
   )
 >()
-external ffi.Pointer<ConnectionPool> pkg_sqlite3_connection_pool_open(
+external void pkg_sqlite3_connection_pool_open(
   ffi.Pointer<ffi.Uint8> name,
   int name_len,
-  ffi.Pointer<ffi.NativeFunction<ffi.Pointer<InitializedPool> Function()>>
-  initialize,
+  ffi.Pointer<ffi.Pointer<UninitializedPool>> initializer,
+  ffi.Pointer<ffi.Pointer<ConnectionPool>> pool,
 );
 
 @ffi.Native<
@@ -163,6 +180,12 @@ class _SymbolAddresses {
   >
   get pkg_sqlite3_connection_pool_close =>
       ffi.Native.addressOf(self.pkg_sqlite3_connection_pool_close);
+  ffi.Pointer<
+    ffi.NativeFunction<ffi.Void Function(ffi.Pointer<UninitializedPool>)>
+  >
+  get pkg_sqlite3_connection_pool_close_uninitialized => ffi.Native.addressOf(
+    self.pkg_sqlite3_connection_pool_close_uninitialized,
+  );
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<PoolRequest>)>>
   get pkg_sqlite3_connection_pool_request_close =>
       ffi.Native.addressOf(self.pkg_sqlite3_connection_pool_request_close);
@@ -309,3 +332,5 @@ final class PoolConnection extends ffi.Struct {
 }
 
 final class PoolRequest extends ffi.Opaque {}
+
+final class UninitializedPool extends ffi.Opaque {}

--- a/sqlite3_connection_pool/lib/src/pool.dart
+++ b/sqlite3_connection_pool/lib/src/pool.dart
@@ -164,7 +164,7 @@ final class SqliteConnectionPool {
     Future<void>? abortSignal,
   ) async {
     _checkNotClosed();
-    final (request, future) = writer ? _raw.requestWrite() : _raw.requestRead();
+    final (request, future) = _raw.requestSingleConnection(!writer);
     _installAbortSignal(request, abortSignal);
 
     final connectionPointer = await future;

--- a/sqlite3_connection_pool/lib/src/raw.dart
+++ b/sqlite3_connection_pool/lib/src/raw.dart
@@ -93,26 +93,19 @@ final class RawSqliteConnectionPool implements Finalizable {
     return (id, _outstandingRequests[id] = Completer());
   }
 
-  (RawPoolRequest, Future<PoolConnectionRef>) requestRead() {
+  (RawPoolRequest, Future<PoolConnectionRef>) requestSingleConnection(
+    bool read,
+  ) {
     final (tag, completer) = _createRequest();
     final request = RawPoolRequest._(
       tag,
       this,
-      pkg_sqlite3_connection_pool_obtain_read(_pool, tag, _nativePort),
-    );
-
-    return (
-      request,
-      completer.future.then((f) => (f as _SingleConnectionLease)._connection),
-    );
-  }
-
-  (RawPoolRequest, Future<PoolConnectionRef>) requestWrite() {
-    final (tag, completer) = _createRequest();
-    final request = RawPoolRequest._(
-      tag,
-      this,
-      pkg_sqlite3_connection_pool_obtain_write(_pool, tag, _nativePort),
+      pkg_sqlite3_connection_pool_obtain_single(
+        _pool,
+        tag,
+        _nativePort,
+        read ? 1 : 0,
+      ),
     );
 
     return (

--- a/sqlite3_connection_pool/lib/src/raw.dart
+++ b/sqlite3_connection_pool/lib/src/raw.dart
@@ -174,80 +174,75 @@ final class RawSqliteConnectionPool implements Finalizable {
     String name,
     PoolConnections Function() open,
   ) {
-    (Object, StackTrace)? openException;
-
-    final pool = using((alloc) {
+    return using((alloc) {
       final encoded = utf8.encode(name);
       final namePtr = alloc<Uint8>(encoded.length);
+      final initializerAndPool = alloc<Pointer<Void>>(2);
+      final initializerOut = initializerAndPool
+          .cast<Pointer<UninitializedPool>>();
+      final poolClientOut = (initializerAndPool + 1)
+          .cast<Pointer<ConnectionPool>>();
+
       namePtr.asTypedList(encoded.length).setAll(0, encoded);
 
-      final initializeCallable =
-          NativeCallable<Pointer<InitializedPool> Function()>.isolateLocal(() {
-            final initOptionsPtr = alloc<InitializedPool>();
-            final initOptions = initOptionsPtr.ref;
-            initOptions.functions
-              ..sqlite3_update_hook = libsqlite3.addresses.sqlite3_update_hook
-                  .cast()
-              ..sqlite3_rollback_hook = libsqlite3
-                  .addresses
-                  .sqlite3_rollback_hook
-                  .cast()
-              ..sqlite3_commit_hook = libsqlite3.addresses.sqlite3_commit_hook
-                  .cast()
-              ..sqlite3_get_autocommit = libsqlite3
-                  .addresses
-                  .sqlite3_get_autocommit
-                  .cast()
-              ..sqlite3_finalize = libsqlite3.addresses.sqlite3_finalize.cast()
-              ..sqlite3_close_v2 = libsqlite3.addresses.sqlite3_close_v2.cast()
-              ..dart_post_c_object = NativeApi.postCObject.cast();
-
-            try {
-              final PoolConnections(
-                :readers,
-                :writer,
-                :preparedStatementCacheSize,
-                :enableNativeUpdateHooks,
-              ) = open();
-
-              initOptions.write = writer.leak().cast();
-              initOptions.read_count = readers.length;
-              initOptions.reads = alloc(readers.length);
-              initOptions.prepared_statement_cache_size =
-                  preparedStatementCacheSize;
-              initOptions.enable_update_hooks = enableNativeUpdateHooks ? 1 : 0;
-
-              for (final (i, reader) in readers.indexed) {
-                (initOptions.reads + i).value = reader.leak().cast();
-              }
-            } catch (e, s) {
-              openException = (e, s);
-              return nullptr;
-            }
-
-            return initOptionsPtr;
-          });
-
-      final connection = pkg_sqlite3_connection_pool_open(
+      pkg_sqlite3_connection_pool_open(
         namePtr,
         encoded.length,
-        initializeCallable.nativeFunction,
+        initializerOut,
+        poolClientOut,
       );
-      initializeCallable.close();
-      return connection;
-    });
 
-    if (pool.address == 0) {
-      if (openException case (final exception, final trace)?) {
-        // Couldn't open because the callback threw an exception, rethrow that.
-        Error.throwWithStackTrace(exception, trace);
+      final initializer = initializerOut.value;
+      final poolClient = poolClientOut.value;
+
+      // If a pool with this name already exists, it is written to poolClient.
+      if (poolClient.address != 0) {
+        return RawSqliteConnectionPool._(poolClient);
       }
 
-      // Unreachable, opening a pool can only fail due to the callback throwing.
-      throw AssertionError();
-    }
+      // Otherwise, we're given an initializer and it's our responsibility to
+      // open the pool now.
+      assert(initializer.address != 0);
 
-    return RawSqliteConnectionPool._(pool);
+      final initOptionsPtr = alloc<InitializedPool>();
+      final initOptions = initOptionsPtr.ref;
+      initOptions.functions
+        ..sqlite3_update_hook = libsqlite3.addresses.sqlite3_update_hook.cast()
+        ..sqlite3_rollback_hook = libsqlite3.addresses.sqlite3_rollback_hook
+            .cast()
+        ..sqlite3_commit_hook = libsqlite3.addresses.sqlite3_commit_hook.cast()
+        ..sqlite3_get_autocommit = libsqlite3.addresses.sqlite3_get_autocommit
+            .cast()
+        ..sqlite3_finalize = libsqlite3.addresses.sqlite3_finalize.cast()
+        ..sqlite3_close_v2 = libsqlite3.addresses.sqlite3_close_v2.cast()
+        ..dart_post_c_object = NativeApi.postCObject.cast();
+
+      try {
+        final PoolConnections(
+          :readers,
+          :writer,
+          :preparedStatementCacheSize,
+          :enableNativeUpdateHooks,
+        ) = open();
+
+        initOptions.write = writer.leak().cast();
+        initOptions.read_count = readers.length;
+        initOptions.reads = alloc(readers.length);
+        initOptions.prepared_statement_cache_size = preparedStatementCacheSize;
+        initOptions.enable_update_hooks = enableNativeUpdateHooks ? 1 : 0;
+
+        for (final (i, reader) in readers.indexed) {
+          (initOptions.reads + i).value = reader.leak().cast();
+        }
+
+        return RawSqliteConnectionPool._(
+          pkg_sqlite3_connection_pool_initialize(initializer, initOptionsPtr),
+        );
+      } on Object {
+        pkg_sqlite3_connection_pool_close_uninitialized(initializer);
+        rethrow;
+      }
+    });
   }
 }
 

--- a/sqlite3_connection_pool/src/headers.h
+++ b/sqlite3_connection_pool/src/headers.h
@@ -3,6 +3,7 @@
 
 typedef struct ConnectionPool ConnectionPool;
 typedef struct PoolRequest PoolRequest;
+typedef struct UninitializedPool UninitializedPool;
 
 typedef const void* Connection;
 
@@ -29,13 +30,16 @@ typedef struct InitializedPool {
   unsigned char enable_update_hooks;
 } InitializedPool;
 
-typedef struct InitializedPool* (*PoolInitializer)(void);
-
 typedef int64_t DartPort;
 
-ConnectionPool* pkg_sqlite3_connection_pool_open(const uint8_t* name,
-                                                 uintptr_t name_len,
-                                                 PoolInitializer initialize);
+void pkg_sqlite3_connection_pool_open(const uint8_t* name, uintptr_t name_len,
+                                      UninitializedPool** initializer,
+                                      ConnectionPool** pool);
+
+ConnectionPool* pkg_sqlite3_connection_pool_initialize(
+    UninitializedPool* uninitialized, const InitializedPool* pool);
+void pkg_sqlite3_connection_pool_close_uninitialized(
+    UninitializedPool* uninitialized);
 
 void pkg_sqlite3_connection_pool_close(const ConnectionPool* pool);
 

--- a/sqlite3_connection_pool/src/headers.h
+++ b/sqlite3_connection_pool/src/headers.h
@@ -39,12 +39,8 @@ ConnectionPool* pkg_sqlite3_connection_pool_open(const uint8_t* name,
 
 void pkg_sqlite3_connection_pool_close(const ConnectionPool* pool);
 
-PoolRequest* pkg_sqlite3_connection_pool_obtain_read(const ConnectionPool* pool,
-                                                     int64_t tag,
-                                                     DartPort port);
-
-PoolRequest* pkg_sqlite3_connection_pool_obtain_write(
-    const ConnectionPool* pool, int64_t tag, DartPort port);
+PoolRequest* pkg_sqlite3_connection_pool_obtain_single(
+    const ConnectionPool* pool, int64_t tag, DartPort port, char read);
 
 PoolRequest* pkg_sqlite3_connection_pool_obtain_exclusive(
     const ConnectionPool* pool, int64_t tag, DartPort port);

--- a/sqlite3_connection_pool/src/lib.rs
+++ b/sqlite3_connection_pool/src/lib.rs
@@ -2,9 +2,10 @@ use crate::client::PoolClient;
 use crate::connection::{Connection, PreparedStatement};
 use crate::dart::DartPort;
 use crate::pool::{ConnectionPool, PendingMessage, PoolConnection, PoolRequestHandle, PoolState};
-use crate::registry::{PoolInitializer, PoolRegistry};
+use crate::registry::{InitializedPool, MaybeInitializedPool, PoolRegistry, UninitializedPool};
 use crate::update_hook::send_update_notification;
 use std::ffi::{CStr, c_char, c_int, c_void};
+use std::mem::MaybeUninit;
 use std::ptr::NonNull;
 use std::sync::{Arc, Mutex};
 use std::{ptr, slice};
@@ -16,19 +17,61 @@ mod pool;
 mod registry;
 mod update_hook;
 
+fn to_client(pool: ConnectionPool) -> NonNull<PoolClient> {
+    let boxed = Box::new(PoolClient::new(pool));
+    let ptr = Box::into_raw(boxed);
+    unsafe { NonNull::new_unchecked(ptr) }
+}
+
+/// Attempts to open a connection pool with the given utf-8 encoded name.
+///
+/// If a pool with that name exists, it is written to `client` and `initializer` is set to [None].
+///
+/// Otherwise `client` is set to [None] and the [UninitializedPool] is heap-allocated and written to
+/// `initializer`. The unitialized pool must be completed with either a call to
+/// [pkg_sqlite3_connection_pool_initialize] or to
+/// [pkg_sqlite3_connection_pool_close_uninitialized].
 #[unsafe(no_mangle)]
 extern "C" fn pkg_sqlite3_connection_pool_open(
     name: *const u8,
     name_len: usize,
-    initialize: PoolInitializer,
-) -> Option<NonNull<PoolClient>> {
+    initializer: &mut MaybeUninit<Option<NonNull<UninitializedPool<'_>>>>,
+    client: &mut MaybeUninit<Option<NonNull<PoolClient>>>,
+) {
     let name = unsafe { str::from_utf8_unchecked(slice::from_raw_parts(name, name_len)) };
 
-    PoolRegistry::lookup(name, initialize).map(|pool| {
-        let client = PoolClient::new(pool);
+    match PoolRegistry::lookup(name) {
+        MaybeInitializedPool::Pool(pool) => {
+            initializer.write(None);
+            client.write(Some(to_client(pool)));
+        }
+        MaybeInitializedPool::Uninitialized(uninitialized_pool) => {
+            client.write(None);
+            let boxed = Box::new(uninitialized_pool);
+            let ptr = Box::into_raw(boxed);
+            initializer.write(Some(unsafe { NonNull::new_unchecked(ptr) }));
+        }
+    }
+}
 
-        unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(client))) }
-    })
+/// Consumes an uninitialized pool by transforming it into an opened connection pool.
+#[unsafe(no_mangle)]
+extern "C" fn pkg_sqlite3_connection_pool_initialize(
+    uninitialized: NonNull<UninitializedPool>,
+    initialize: &InitializedPool,
+) -> NonNull<PoolClient> {
+    let guard = unsafe { Box::from_raw(uninitialized.as_ptr()) };
+    to_client(guard.initialize(initialize))
+}
+
+/// Consumes an uninitialized pool by releasing resources without turning it into an opened
+/// connection pool.
+#[unsafe(no_mangle)]
+extern "C" fn pkg_sqlite3_connection_pool_close_uninitialized(
+    uninitialized: NonNull<UninitializedPool>,
+) {
+    let guard = unsafe { Box::from_raw(uninitialized.as_ptr()) };
+    drop(guard);
 }
 
 #[unsafe(no_mangle)]

--- a/sqlite3_connection_pool/src/lib.rs
+++ b/sqlite3_connection_pool/src/lib.rs
@@ -45,33 +45,21 @@ fn clone_arc(pool: &Mutex<PoolState>) -> ConnectionPool {
 }
 
 #[unsafe(no_mangle)]
-extern "C" fn pkg_sqlite3_connection_pool_obtain_read(
+extern "C" fn pkg_sqlite3_connection_pool_obtain_single(
     client: &PoolClient,
     tag: i64,
     port: DartPort,
+    read: c_char,
 ) -> *mut PoolRequestHandle {
     let pool = &client.pool;
     let mut state = pool.lock().unwrap();
     let pool = clone_arc(pool);
 
-    Box::into_raw(Box::new(
-        state.request_read(pool, PendingMessage { tag, port }),
-    ))
-}
-
-#[unsafe(no_mangle)]
-extern "C" fn pkg_sqlite3_connection_pool_obtain_write(
-    client: &PoolClient,
-    tag: i64,
-    port: DartPort,
-) -> *mut PoolRequestHandle {
-    let pool = &client.pool;
-    let mut state = pool.lock().unwrap();
-    let pool = clone_arc(pool);
-
-    Box::into_raw(Box::new(
-        state.request_write(pool, PendingMessage { tag, port }),
-    ))
+    Box::into_raw(Box::new(state.request_single(
+        pool,
+        PendingMessage { tag, port },
+        read != 0,
+    )))
 }
 
 #[unsafe(no_mangle)]

--- a/sqlite3_connection_pool/src/pool.rs
+++ b/sqlite3_connection_pool/src/pool.rs
@@ -240,16 +240,21 @@ impl PoolState {
         }
     }
 
-    pub fn request_read(&mut self, pool: ConnectionPool, msg: PendingMessage) -> PoolRequestHandle {
-        self.register_waiter(pool, msg, Waiter::Reader(Default::default()))
-    }
-
-    pub fn request_write(
+    pub fn request_single(
         &mut self,
         pool: ConnectionPool,
         msg: PendingMessage,
+        read: bool,
     ) -> PoolRequestHandle {
-        self.register_waiter(pool, msg, Waiter::Writer(Default::default()))
+        self.register_waiter(
+            pool,
+            msg,
+            if read {
+                Waiter::Reader(Default::default())
+            } else {
+                Waiter::Writer(Default::default())
+            },
+        )
     }
 
     pub fn request_exclusive(

--- a/sqlite3_connection_pool/src/registry.rs
+++ b/sqlite3_connection_pool/src/registry.rs
@@ -2,15 +2,24 @@ use crate::connection::Connection;
 use crate::pool::{ConnectionPool, ExternalFunctions, PoolState};
 use std::collections::HashMap;
 use std::ffi::c_uchar;
-use std::ptr::NonNull;
 use std::slice;
-use std::sync::{Arc, LazyLock, Mutex, Weak};
+use std::sync::{Arc, LazyLock, Mutex, MutexGuard, Weak};
 
 static REGISTRY: LazyLock<PoolRegistry> = LazyLock::new(|| PoolRegistry::default());
 
 #[derive(Default)]
 pub struct PoolRegistry {
     pools: Mutex<HashMap<String, Weak<Mutex<PoolState>>>>,
+}
+
+pub struct UninitializedPool<'a> {
+    name: &'a str,
+    guard: MutexGuard<'a, HashMap<String, Weak<Mutex<PoolState>>>>,
+}
+
+pub enum MaybeInitializedPool<'a> {
+    Pool(ConnectionPool),
+    Uninitialized(UninitializedPool<'a>),
 }
 
 #[repr(C)]
@@ -23,27 +32,25 @@ pub struct InitializedPool {
     enable_update_hooks: c_uchar,
 }
 
-pub type PoolInitializer = extern "C" fn() -> Option<NonNull<InitializedPool>>;
-
 impl PoolRegistry {
-    fn lookup_internal(&self, name: &str, initialize: PoolInitializer) -> Option<ConnectionPool> {
-        let mut pools = self.pools.lock().unwrap();
+    fn lookup_internal<'a>(&'a self, name: &'a str) -> MaybeInitializedPool<'a> {
+        let pools = self.pools.lock().unwrap();
         if let Some(pool) = pools.get(name) {
             if let Some(pool) = Weak::upgrade(pool) {
-                return Some(pool);
+                return MaybeInitializedPool::Pool(pool);
             }
         };
 
-        // The pool doesn't exist, obtain connections from Dart callback.
-        let Some(initialized) = initialize() else {
-            // Initialization failed, don't insert a pool.
-            return None;
-        };
-        let initialized = unsafe {
-            // The returned pointer is valid until this function returns.
-            initialized.as_ref()
-        };
+        return MaybeInitializedPool::Uninitialized(UninitializedPool { name, guard: pools });
+    }
 
+    pub fn lookup<'a>(name: &'a str) -> MaybeInitializedPool<'a> {
+        REGISTRY.lookup_internal(name)
+    }
+}
+
+impl<'a> UninitializedPool<'a> {
+    pub fn initialize(mut self, initialized: &InitializedPool) -> ConnectionPool {
         let state = PoolState::new(
             initialized.functions,
             initialized.write,
@@ -55,11 +62,8 @@ impl PoolRegistry {
         let pool = ConnectionPool::new(Mutex::new(state));
         PoolState::register_hooks_on_writer(&pool);
 
-        pools.insert(name.to_string(), Arc::downgrade(&pool));
-        Some(pool)
-    }
-
-    pub fn lookup(name: &str, initialize: PoolInitializer) -> Option<ConnectionPool> {
-        REGISTRY.lookup_internal(name, initialize)
+        self.guard
+            .insert(self.name.to_string(), Arc::downgrade(&pool));
+        pool
     }
 }


### PR DESCRIPTION
`NativeCallable` and `Pointer.fromFunction` are implemented by the Dart VM allocating an FFI stub in a page that is then remapped as executable. This is forbidden on some platforms like GrapheneOS.

To avoid that issue, this splits the `pkg_sqlite3_connection_pool_open` function into three parts:

1. `pkg_sqlite3_connection_pool_open` locks the global mutex of active pools and either returns a handle to the opened pool if it exists already, or indicates that the caller is responsible for initialization.
2. `pkg_sqlite3_connection_pool_initialize` takes the role of what used to be a callback, turning an initialized pool into a pool client and unlocking.
3. `pkg_sqlite3_connection_pool_close_uninitialized` drops an uninitialized handle without creating a pool, used on exceptions.

Closes https://github.com/simolus3/sqlite3.dart/issues/396.