### PR TITLE
Fix async OPFS offsets beyond 2 GiB

### DIFF
--- a/sqlite3/lib/src/wasm/vfs/async_opfs/sync_channel.dart
+++ b/sqlite3/lib/src/wasm/vfs/async_opfs/sync_channel.dart
@@ -3,7 +3,7 @@ import 'dart:typed_data';
 
 import '../../js_interop.dart';
 
-const protocolVersion = 1;
+const protocolVersion = 2;
 const asyncIdleWaitTimeMs = 150;
 const asyncIdleWaitTime = Duration(milliseconds: asyncIdleWaitTimeMs);
 
@@ -103,16 +103,35 @@ class MessageSerializer {
     if (message is EmptyMessage) {
       // Nothing to do
     } else if (message is Flags) {
-      dataView.setInt32(0, message.flag0);
-      dataView.setInt32(4, message.flag1);
-      dataView.setInt32(8, message.flag2);
+      // File offsets and sizes can exceed the signed 32-bit range. Dart
+      // integers compiled to JavaScript are exact up to 53 bits, which covers
+      // SQLite's maximum database size. ByteData's int64 accessors are not
+      // supported by dart2js, so encode each value as low/high 32-bit words.
+      _writeInt64(0, message.flag0);
+      _writeInt64(8, message.flag1);
+      _writeInt64(16, message.flag2);
 
       if (message is NameAndInt32Flags) {
-        _writeString(12, message.name);
+        _writeString(24, message.name);
       }
     } else {
       throw UnsupportedError('Message $message');
     }
+  }
+
+  static const _uint32Range = 0x100000000;
+
+  void _writeInt64(int offset, int value) {
+    final high = (value / _uint32Range).floor();
+    final low = value - high * _uint32Range;
+    dataView.setUint32(offset, low);
+    dataView.setInt32(offset + 4, high);
+  }
+
+  int _readInt64(int offset) {
+    final low = dataView.getUint32(offset);
+    final high = dataView.getInt32(offset + 4);
+    return high * _uint32Range + low;
   }
 
   Uint8List viewByteRange(int offset, int length) {
@@ -140,19 +159,15 @@ class MessageSerializer {
   }
 
   static Flags readFlags(MessageSerializer msg) {
-    return Flags(
-      msg.dataView.getInt32(0),
-      msg.dataView.getInt32(4),
-      msg.dataView.getInt32(8),
-    );
+    return Flags(msg._readInt64(0), msg._readInt64(8), msg._readInt64(16));
   }
 
   static NameAndInt32Flags readNameAndFlags(MessageSerializer msg) {
     return NameAndInt32Flags(
-      msg._readString(12),
-      msg.dataView.getInt32(0),
-      msg.dataView.getInt32(4),
-      msg.dataView.getInt32(8),
+      msg._readString(24),
+      msg._readInt64(0),
+      msg._readInt64(8),
+      msg._readInt64(16),
     );
   }
 }

--- a/sqlite3/test/wasm/sync_channel_test.dart
+++ b/sqlite3/test/wasm/sync_channel_test.dart
@@ -1,0 +1,52 @@
+@TestOn('browser')
+@Tags(['wasm'])
+library;
+
+import 'package:sqlite3/src/wasm/js_interop.dart';
+import 'package:sqlite3/src/wasm/vfs/async_opfs/sync_channel.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('OPFS message serializer', () {
+    late MessageSerializer serializer;
+
+    setUp(() {
+      serializer = MessageSerializer(
+        SharedArrayBuffer(MessageSerializer.totalSize),
+      );
+    });
+
+    test('round-trips file offsets and sizes beyond 2 GiB', () {
+      const values = [
+        -1,
+        0,
+        0x7fffffff,
+        0x80000000,
+        0x100000000,
+        // SQLite's maximum page count with its maximum 64 KiB page size.
+        0xffff_fffe_0000,
+      ];
+
+      for (final value in values) {
+        serializer.write(Flags(value, value, value));
+        final decoded = MessageSerializer.readFlags(serializer);
+
+        expect(decoded.flag0, value);
+        expect(decoded.flag1, value);
+        expect(decoded.flag2, value);
+      }
+    });
+
+    test('keeps filename metadata separate from 64-bit flags', () {
+      serializer.write(
+        NameAndInt32Flags('/nested/database.sqlite', 0x80000000, -1, 42),
+      );
+
+      final decoded = MessageSerializer.readNameAndFlags(serializer);
+      expect(decoded.name, '/nested/database.sqlite');
+      expect(decoded.flag0, 0x80000000);
+      expect(decoded.flag1, -1);
+      expect(decoded.flag2, 42);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

The async OPFS VFS transports `WasmFile` offsets, truncate sizes and `xFileSize` results through three signed 32-bit fields in `MessageSerializer`. Once a database exceeds 2 GiB, those values wrap negative. Reads then target incorrect offsets and SQLite reports generic SQL errors/corruption despite valid data.

This changes the three protocol fields to signed 64-bit values encoded as low-uint32/high-int32 pairs. That representation works in dart2js (where `ByteData.setInt64` is unsupported) while preserving every JavaScript-safe integer. SQLite's maximum practical file size is below the 53-bit exact-integer limit.

The protocol version is bumped and filename metadata moves from byte 12 to byte 24.

## Reproduction

A production encrypted OPFS database failed deterministically just after crossing the boundary:

- `page_count = 263872`
- `page_size = 8192`
- file size = `2161639424` bytes
- ordinary INSERT returned `SQLITE_ERROR`
- reads and `PRAGMA quick_check` then reported unrelated page failures
- the identical workload on a smaller database passed

With this patch, the same production workload completes and reopens cleanly at:

- 2,112 transactions / 415,027 inserted rows
- `page_count = 281492`
- `page_size = 8192`
- file size = `2305982464` bytes
- `PRAGMA integrity_check` passes
- FTS5 integrity check passes
- close/reopen integrity checks pass

## Tests

Added browser serializer tests around:

- signed 32-bit maximum
- 2 GiB boundary
- 4 GiB boundary
- SQLite's maximum practical database size
- negative sentinel values
- filename metadata adjacent to widened flags

Validated under both dart2js and dart2wasm Chrome test platforms.
