### PR TITLE
feat: Add native bindings for `sqlite3_interrupt` and `sqlite3_is_interrupted`

### DIFF
--- a/sqlite3/CHANGELOG.md
+++ b/sqlite3/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Hooks: Support relative paths in `additional_includes` and `additional_lib_directories`.
 - Hooks: Support multiple source files to compile with `source: source`.
-- Add native bindings for `sqlite3_interrupt`, available through the unstable `ffi_bindings.dart` library.
+- Add native bindings for `sqlite3_interrupt` and `sqlite3_is_interrupted`, available through the unstable `ffi_bindings.dart` library.
 
 ## 3.5.2
 

--- a/sqlite3/CHANGELOG.md
+++ b/sqlite3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Hooks: Support relative paths in `additional_includes` and `additional_lib_directories`.
 - Hooks: Support multiple source files to compile with `source: source`.
+- Add native bindings for `sqlite3_interrupt`, available through the unstable `ffi_bindings.dart` library.
 
 ## 3.5.2
 

--- a/sqlite3/assets/sqlite3.h
+++ b/sqlite3/assets/sqlite3.h
@@ -49,6 +49,7 @@ void* sqlite3_update_hook(sqlite3*,
 void* sqlite3_commit_hook(sqlite3*, int (*)(void*), void*);
 void* sqlite3_rollback_hook(sqlite3*, void (*)(void*), void*);
 int sqlite3_get_autocommit(sqlite3* db);
+void sqlite3_interrupt(sqlite3* db);
 
 // Statements
 int sqlite3_prepare_v2(sqlite3* db, const sqlite3_char* zSql, int nByte,

--- a/sqlite3/assets/sqlite3.h
+++ b/sqlite3/assets/sqlite3.h
@@ -50,6 +50,7 @@ void* sqlite3_commit_hook(sqlite3*, int (*)(void*), void*);
 void* sqlite3_rollback_hook(sqlite3*, void (*)(void*), void*);
 int sqlite3_get_autocommit(sqlite3* db);
 void sqlite3_interrupt(sqlite3* db);
+int sqlite3_is_interrupted(sqlite3* db);
 
 // Statements
 int sqlite3_prepare_v2(sqlite3* db, const sqlite3_char* zSql, int nByte,

--- a/sqlite3/lib/src/ffi/libsqlite3.g.dart
+++ b/sqlite3/lib/src/ffi/libsqlite3.g.dart
@@ -451,6 +451,9 @@ external int sqlite3_get_autocommit(ffi.Pointer<sqlite3> db);
 @ffi.Native<ffi.Int Function()>()
 external int sqlite3_initialize();
 
+@ffi.Native<ffi.Void Function(ffi.Pointer<sqlite3>)>()
+external void sqlite3_interrupt(ffi.Pointer<sqlite3> db);
+
 @ffi.Native<ffi.Int64 Function(ffi.Pointer<sqlite3>)>(isLeaf: true)
 external int sqlite3_last_insert_rowid(ffi.Pointer<sqlite3> db);
 
@@ -1208,6 +1211,8 @@ class _SymbolAddresses {
       ffi.Native.addressOf(self.sqlite3_get_autocommit);
   ffi.Pointer<ffi.NativeFunction<ffi.Int Function()>> get sqlite3_initialize =>
       ffi.Native.addressOf(self.sqlite3_initialize);
+  ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<sqlite3>)>>
+  get sqlite3_interrupt => ffi.Native.addressOf(self.sqlite3_interrupt);
   ffi.Pointer<ffi.NativeFunction<ffi.Int64 Function(ffi.Pointer<sqlite3>)>>
   get sqlite3_last_insert_rowid =>
       ffi.Native.addressOf(self.sqlite3_last_insert_rowid);

--- a/sqlite3/lib/src/ffi/libsqlite3.g.dart
+++ b/sqlite3/lib/src/ffi/libsqlite3.g.dart
@@ -454,6 +454,9 @@ external int sqlite3_initialize();
 @ffi.Native<ffi.Void Function(ffi.Pointer<sqlite3>)>()
 external void sqlite3_interrupt(ffi.Pointer<sqlite3> db);
 
+@ffi.Native<ffi.Int Function(ffi.Pointer<sqlite3>)>()
+external int sqlite3_is_interrupted(ffi.Pointer<sqlite3> db);
+
 @ffi.Native<ffi.Int64 Function(ffi.Pointer<sqlite3>)>(isLeaf: true)
 external int sqlite3_last_insert_rowid(ffi.Pointer<sqlite3> db);
 
@@ -1213,6 +1216,9 @@ class _SymbolAddresses {
       ffi.Native.addressOf(self.sqlite3_initialize);
   ffi.Pointer<ffi.NativeFunction<ffi.Void Function(ffi.Pointer<sqlite3>)>>
   get sqlite3_interrupt => ffi.Native.addressOf(self.sqlite3_interrupt);
+  ffi.Pointer<ffi.NativeFunction<ffi.Int Function(ffi.Pointer<sqlite3>)>>
+  get sqlite3_is_interrupted =>
+      ffi.Native.addressOf(self.sqlite3_is_interrupted);
   ffi.Pointer<ffi.NativeFunction<ffi.Int64 Function(ffi.Pointer<sqlite3>)>>
   get sqlite3_last_insert_rowid =>
       ffi.Native.addressOf(self.sqlite3_last_insert_rowid);

--- a/sqlite3/lib/src/hook/compile/used_symbols.dart
+++ b/sqlite3/lib/src/hook/compile/used_symbols.dart
@@ -48,6 +48,7 @@ const usedSqliteSymbols = {
   'sqlite3_get_autocommit',
   'sqlite3_initialize',
   'sqlite3_interrupt',
+  'sqlite3_is_interrupted',
   'sqlite3_last_insert_rowid',
   'sqlite3_libversion',
   'sqlite3_libversion_number',

--- a/sqlite3/lib/src/hook/compile/used_symbols.dart
+++ b/sqlite3/lib/src/hook/compile/used_symbols.dart
@@ -47,6 +47,7 @@ const usedSqliteSymbols = {
   'sqlite3_free',
   'sqlite3_get_autocommit',
   'sqlite3_initialize',
+  'sqlite3_interrupt',
   'sqlite3_last_insert_rowid',
   'sqlite3_libversion',
   'sqlite3_libversion_number',


### PR DESCRIPTION
# Add bindings for `sqlite3_interrupt` and `sqlite3_is_interrupted`

Two declarations in `assets/sqlite3.h`, the rest is `tool/generate_bindings.dart` output. No public API, they only show up in `unstable/ffi_bindings.dart`, plus the `used_symbols` entries so the symbols survive a `source:` build. `sqlite3_is_interrupted` needs SQLite 3.41+, same situation as `sqlite3_error_offset` which is already bound.

I need it to cancel superseded queries in an interactive search. Nothing in Dart can stop a statement that already sits in `sqlite3_step`, since the isolate running it never gets to read a cancellation message and `Isolate.kill` has no safepoint to land on.

I left wasm out because that build is single threaded and every worker has its own memory, so nothing could call interrupt while a statement runs. Easy to add if you disagree.

What I'm actually after is drift interrupting the connection when a request is cancelled, so it can stop a statement that is already running instead of only skipping ones that have not started yet. The isolate doing that never owns the `Database`, it only has the handle address, so drift would have to go through `unstable/ffi_bindings.dart`. Is that fine to depend on, or would you rather expose something stable taking a `Pointer<void>`? I can move this to a drift issue if you'd rather keep it out of here.
