### PR TITLE
Hook: allow source_<os> user-defines and path-like names for source: system

### DIFF
--- a/sqlite3/CHANGELOG.md
+++ b/sqlite3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Hooks: Support relative paths in `additional_includes` and `additional_lib_directories`.
 - Hooks: Support multiple source files to compile with `source: source`.
+- Hooks: Allow `source_<os>` user-defines and path-like `name`s for `source: system`.
 
 ## 3.5.2
 

--- a/sqlite3/CHANGELOG.md
+++ b/sqlite3/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Hooks: Support relative paths in `additional_includes` and `additional_lib_directories`.
 - Hooks: Support multiple source files to compile with `source: source`.
-- Hooks: Allow `source_<os>` user-defines and path-like `name`s for `source: system`.
+- Hooks: `source` and `name` accept a map with per-OS entries and a `default` (e.g. `source: {android: system, default: sqlite3}`). Names containing a path (like `foo.framework/foo`) are passed to the loader as-is with `source: system`.
 
 ## 3.5.2
 

--- a/sqlite3/doc/hook.md
+++ b/sqlite3/doc/hook.md
@@ -141,21 +141,23 @@ hooks:
       # Names like `@rpath/libsqlite3.dylib` are supported as well.
 ```
 
-### Per-OS sources
+### Per-OS sources and names
 
-Like `name`, the `source` key can be overridden for specific operating systems with `source_$os`
-keys. This allows using a library from the system (or from the app) on some platforms while
-keeping the default binaries on others:
+`source` and `name` can also be maps from target operating systems to values. The `default`
+entry applies to operating systems not listed in the map (without it, the key is treated as
+unset for those):
 
 ```yaml
 hooks:
   user_defines:
     sqlite3:
-      source: sqlite3 # default, used for platforms not listed below
-      source_android: system
-      source_ios: system
-      name_android: my_native_lib
-      name_ios: my_native_lib.framework/my_native_lib
+      source:
+        android: system
+        ios: system
+        default: sqlite3
+      name:
+        android: my_native_lib
+        ios: my_native_lib.framework/my_native_lib
 ```
 
 ## Custom SQLite builds

--- a/sqlite3/doc/hook.md
+++ b/sqlite3/doc/hook.md
@@ -113,9 +113,10 @@ When using `source: system`, you can also add a `name` key to customize the name
 library.
 For instance, `name: sqlcipher` would load `libsqlcipher.dylib` on macOS, `libsqlcipher.so` on Linux
 and `sqlcipher.dll` on Windows.
-To further customize the name for specific operating systems, you can use `name_$os` keys, where `$os`
-is the [target operating system](https://pub.dev/documentation/code_assets/latest/code_assets/OS-class.html)
-passed to hooks:
+To further customize the name for specific operating systems, `name` can be a map with an entry per
+[target operating system](https://pub.dev/documentation/code_assets/latest/code_assets/OS-class.html)
+passed to hooks. The `default` entry applies to operating systems not listed in the map, and the
+package's usual default (`sqlite3`) is used for them if there is no `default` entry either:
 
 ```yaml
 hooks:
@@ -123,9 +124,13 @@ hooks:
     sqlite3:
       source: system
       # Use winsqlite3.dll on Windows, libsqlite3.{so,dylib} on Linux and macOS
-      name_windows: winsqlite3
-      name: sqlite3
+      name:
+        windows: winsqlite3
+        default: sqlite3
 ```
+
+Earlier versions used `name_$os` keys (e.g. `name_windows: winsqlite3`) for this, which keep
+working and take precedence over `name`.
 
 A name containing a directory component is passed to the dynamic loader as-is instead of being
 turned into a library file name.
@@ -137,15 +142,14 @@ hooks:
   user_defines:
     sqlite3:
       source: system
-      name_ios: my_native_lib.framework/my_native_lib
-      # Names like `@rpath/libsqlite3.dylib` are supported as well.
+      name:
+        ios: my_native_lib.framework/my_native_lib
+        # Names like `@rpath/libsqlite3.dylib` are supported as well.
 ```
 
-### Per-OS sources and names
-
-`source` and `name` can also be maps from target operating systems to values. The `default`
-entry applies to operating systems not listed in the map (without it, the key is treated as
-unset for those):
+The same map syntax is available for `source`, for instance to only use the app's own library on
+mobile platforms. Without a `default` entry, the package falls back to downloading its own binaries
+for the other operating systems:
 
 ```yaml
 hooks:

--- a/sqlite3/doc/hook.md
+++ b/sqlite3/doc/hook.md
@@ -127,6 +127,37 @@ hooks:
       name: sqlite3
 ```
 
+A name containing a directory component is passed to the dynamic loader as-is instead of being
+turned into a library file name.
+On iOS, this can be used to load SQLite from a framework in the app bundle, for instance when
+another native library of the app already links SQLite and exports its symbols:
+
+```yaml
+hooks:
+  user_defines:
+    sqlite3:
+      source: system
+      name_ios: my_native_lib.framework/my_native_lib
+      # Names like `@rpath/libsqlite3.dylib` are supported as well.
+```
+
+### Per-OS sources
+
+Like `name`, the `source` key can be overridden for specific operating systems with `source_$os`
+keys. This allows using a library from the system (or from the app) on some platforms while
+keeping the default binaries on others:
+
+```yaml
+hooks:
+  user_defines:
+    sqlite3:
+      source: sqlite3 # default, used for platforms not listed below
+      source_android: system
+      source_ios: system
+      name_android: my_native_lib
+      name_ios: my_native_lib.framework/my_native_lib
+```
+
 ## Custom SQLite builds
 
 If you want to customize the SQLite build to use with `package:sqlite3`, you can

--- a/sqlite3/lib/src/hook/compile/description.dart
+++ b/sqlite3/lib/src/hook/compile/description.dart
@@ -38,11 +38,28 @@ sealed class SqliteBinary {
       return [for (final path in value) resolvePath(base: baseUri, path: path)];
     }
 
-    // Like `name`, the source can be overridden per target OS with a
-    // `source_$os` key (e.g. `source_ios: system`).
     final targetOS = input.config.code.targetOS;
-    final source =
-        userDefines['source_${targetOS.name}'] ?? userDefines['source'];
+
+    // `source` and `name` are either a string or a map from target OS names
+    // (or `default`) to strings.
+    String? forTargetOS(String key) {
+      final value = userDefines[key];
+      final resolved = value is Map
+          ? value[targetOS.name] ?? value['default']
+          : value;
+
+      return switch (resolved) {
+        null => null,
+        final String string => string,
+        _ => throw ArgumentError.value(
+          value,
+          key,
+          'Expected a string or a map of strings',
+        ),
+      };
+    }
+
+    final source = forTargetOS('source');
 
     switch (source) {
       case null:
@@ -62,7 +79,7 @@ sealed class SqliteBinary {
         final osSpecificNameKey = 'name_${targetOS.name}';
 
         return LookupSystem(
-          ((userDefines[osSpecificNameKey] ?? userDefines['name'] ?? 'sqlite3')
+          ((userDefines[osSpecificNameKey] ?? forTargetOS('name') ?? 'sqlite3')
               as String),
         );
       case 'process':

--- a/sqlite3/lib/src/hook/compile/description.dart
+++ b/sqlite3/lib/src/hook/compile/description.dart
@@ -38,7 +38,13 @@ sealed class SqliteBinary {
       return [for (final path in value) resolvePath(base: baseUri, path: path)];
     }
 
-    switch (userDefines['source']) {
+    // Like `name`, the source can be overridden per target OS with a
+    // `source_$os` key (e.g. `source_ios: system`).
+    final targetOS = input.config.code.targetOS;
+    final source =
+        userDefines['source_${targetOS.name}'] ?? userDefines['source'];
+
+    switch (source) {
       case null:
       case 'sqlite3':
         return fromGitHub(LibraryType.sqlite3);
@@ -53,7 +59,7 @@ sealed class SqliteBinary {
       case 'test-sqlcipher':
         return PrecompiledForTesting(LibraryType.sqlcipher);
       case 'system':
-        final osSpecificNameKey = 'name_${input.config.code.targetOS.name}';
+        final osSpecificNameKey = 'name_${targetOS.name}';
 
         return LookupSystem(
           ((userDefines[osSpecificNameKey] ?? userDefines['name'] ?? 'sqlite3')
@@ -100,7 +106,7 @@ sealed class SqliteBinary {
         );
       default:
         throw ArgumentError.value(
-          userDefines['source'],
+          source,
           'source',
           'Unknown source. Must be sqlite3, sqlite3mc, system, process or '
               'executable',
@@ -127,8 +133,10 @@ final class LookupSystem implements ExternalSqliteBinary {
     final targetOS = input.config.code.targetOS;
     final String dylibName;
 
-    if (p.isAbsolute(name)) {
-      // Interpret name as a file name
+    if (p.isAbsolute(name) || p.split(name).length > 1) {
+      // Interpret name as a path. Relative paths are passed to the dynamic
+      // loader unchanged, which allows loading e.g. `foo.framework/foo` or
+      // `@rpath/libfoo.dylib` on Apple platforms.
       dylibName = name;
     } else {
       dylibName = targetOS.libraryFileName(name, DynamicLoadingBundled());

--- a/sqlite3/lib/src/hook/compile/description.dart
+++ b/sqlite3/lib/src/hook/compile/description.dart
@@ -76,6 +76,7 @@ sealed class SqliteBinary {
       case 'test-sqlcipher':
         return PrecompiledForTesting(LibraryType.sqlcipher);
       case 'system':
+        // For backwards compatibility, before per-OS subkeys were supported.
         final osSpecificNameKey = 'name_${targetOS.name}';
 
         return LookupSystem(

--- a/sqlite3/test/hook/description_test.dart
+++ b/sqlite3/test/hook/description_test.dart
@@ -40,6 +40,41 @@ void main() {
     );
   });
 
+  test('system with path-like name', () async {
+    expect(
+      await systemLinkMode(OS.iOS, {
+        'source': 'system',
+        'name_ios': 'my_lib.framework/my_lib',
+      }),
+      DynamicLoadingSystem(Uri.parse('my_lib.framework/my_lib')),
+    );
+    expect(
+      await systemLinkMode(OS.macOS, {
+        'source': 'system',
+        'name': '@rpath/libsqlcipher.dylib',
+      }),
+      DynamicLoadingSystem(Uri.parse('@rpath/libsqlcipher.dylib')),
+    );
+    // Plain names are still turned into platform-specific file names.
+    expect(
+      await systemLinkMode(OS.iOS, {'source': 'system', 'name': 'sqlcipher'}),
+      DynamicLoadingSystem(Uri.parse('libsqlcipher.dylib')),
+    );
+  });
+
+  test('os-specific source', () async {
+    const defines = {'source': 'sqlite3', 'source_ios': 'system'};
+
+    expect(
+      await resolveForOS(OS.iOS, defines, (_, binary) => binary),
+      isA<LookupSystem>(),
+    );
+    expect(
+      await resolveForOS(OS.macOS, defines, (_, binary) => binary),
+      isA<PrecompiledFromGithubAssets>(),
+    );
+  });
+
   test('resolves relative paths against the pubspec', () async {
     await testBuildHook(
       userDefines: PackageUserDefines(
@@ -128,7 +163,13 @@ void main() {
         });
       },
       check: (_, _) {},
-      extensions: [],
+      extensions: [
+        CodeAssetExtension(
+          targetArchitecture: Architecture.arm64,
+          targetOS: OS.linux,
+          linkModePreference: LinkModePreference.dynamic,
+        ),
+      ],
     );
 
     await testBuildHook(
@@ -154,7 +195,57 @@ void main() {
         });
       },
       check: (_, _) {},
-      extensions: [],
+      extensions: [
+        CodeAssetExtension(
+          targetArchitecture: Architecture.arm64,
+          targetOS: OS.linux,
+          linkModePreference: LinkModePreference.dynamic,
+        ),
+      ],
     );
   });
+}
+
+/// Resolves the [SqliteBinary] for a build targeting [os] with [defines] as
+/// user-defines and returns the result of [body].
+Future<T> resolveForOS<T>(
+  OS os,
+  Map<String, Object?> defines,
+  T Function(BuildInput input, SqliteBinary binary) body,
+) async {
+  late T result;
+  await testBuildHook(
+    userDefines: PackageUserDefines(
+      workspacePubspec: PackageUserDefinesSource(
+        defines: defines,
+        basePath: Uri.file(d.sandbox),
+      ),
+    ),
+    mainMethod: (args) {
+      return build(args, (input, output) async {
+        result = body(input, SqliteBinary.forBuild(input));
+      });
+    },
+    check: (_, _) {},
+    extensions: [
+      CodeAssetExtension(
+        targetArchitecture: Architecture.arm64,
+        targetOS: os,
+        linkModePreference: LinkModePreference.dynamic,
+        iOS: os == OS.iOS
+            ? IOSCodeConfig(targetSdk: IOSSdk.iPhoneOS, targetVersion: 13)
+            : null,
+        macOS: os == OS.macOS ? MacOSCodeConfig(targetVersion: 13) : null,
+      ),
+    ],
+  );
+  return result;
+}
+
+Future<LinkMode> systemLinkMode(OS os, Map<String, Object?> defines) {
+  return resolveForOS(
+    os,
+    defines,
+    (input, binary) => (binary as LookupSystem).resolveLinkMode(input),
+  );
 }

--- a/sqlite3/test/hook/description_test.dart
+++ b/sqlite3/test/hook/description_test.dart
@@ -63,7 +63,9 @@ void main() {
   });
 
   test('os-specific source', () async {
-    const defines = {'source': 'sqlite3', 'source_ios': 'system'};
+    const defines = {
+      'source': {'ios': 'system', 'default': 'sqlite3'},
+    };
 
     expect(
       await resolveForOS(OS.iOS, defines, (_, binary) => binary),
@@ -72,6 +74,38 @@ void main() {
     expect(
       await resolveForOS(OS.macOS, defines, (_, binary) => binary),
       isA<PrecompiledFromGithubAssets>(),
+    );
+  });
+
+  test('os-specific name', () async {
+    const defines = {
+      'source': 'system',
+      'name': {'ios': 'my_lib.framework/my_lib', 'default': 'sqlcipher'},
+    };
+
+    expect(
+      await systemLinkMode(OS.iOS, defines),
+      DynamicLoadingSystem(Uri.parse('my_lib.framework/my_lib')),
+    );
+    expect(
+      await systemLinkMode(OS.macOS, defines),
+      DynamicLoadingSystem(Uri.parse('libsqlcipher.dylib')),
+    );
+  });
+
+  test('map without entry for target os', () async {
+    expect(
+      await resolveForOS(OS.macOS, {
+        'source': {'android': 'system'},
+      }, (_, binary) => binary),
+      isA<PrecompiledFromGithubAssets>(),
+    );
+    expect(
+      await systemLinkMode(OS.macOS, {
+        'source': 'system',
+        'name': {'android': 'my_lib'},
+      }),
+      DynamicLoadingSystem(Uri.parse('libsqlite3.dylib')),
     );
   });
 


### PR DESCRIPTION
Two small additions to the build hook for apps that ship SQLite inside one of their own native libraries.

With `source: system`, a `name` is currently always turned into a platform file name (`libfoo.dylib`, `libfoo.so`, ...). That does not work for a library that is bundled as a framework on iOS, where the loader needs `foo.framework/foo` (or `@rpath/...`). Names with a directory component are now passed to the loader unchanged, absolute paths keep working as before and plain names are still mapped like today.

`source` and `name` can now also be given per operating system as a map (`android: system`, `default: sqlite3` and so on; the existing `name_<os>` keys keep working). Our case, the Immich mobile app: a Rust library in the app already links SQLite with the compile options from this package's binaries and exports the `sqlite3_*` symbols, so on Android and iOS we point `package:sqlite3` at that library (one copy of SQLite in the app) while `flutter test` on the host keeps the default download.

Tests added in `test/hook/description_test.dart` for the path-like names (framework partial, `@rpath/...`, plain name still mapped) and for the per-OS maps (the iOS entry vs `default`, and a map without an entry for the target OS). The existing download url test now passes a code config since the source lookup needs the target OS. Docs in `doc/hook.md` and a changelog line.

Tried it in our app on an iPad simulator: the manifest entry becomes `["system", "immich_core_ffi.framework/immich_core_ffi"]`, no `sqlite3.framework` in the bundle, and `sqlite3_libversion` resolved through the sqlite3 asset lives in the same loaded image as our Rust library.
