### PR TITLE
Await in-flight batch in IndexedDbFileSystem.flush()

### DIFF
--- a/sqlite3/CHANGELOG.md
+++ b/sqlite3/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.6.0 (unreleased)
 
+- Fix `IndexedDbFileSystem.flush()` completing before a write batch already in progress was persisted.
 - Hooks: Support relative paths in `additional_includes` and `additional_lib_directories`.
 - Hooks: Support multiple source files to compile with `source: source`.
 - Hooks: `source` and `name` accept a map with per-OS entries and a `default` (e.g. `source: {android: system, default: sqlite3}`). Names containing a path (like `foo.framework/foo`) are passed to the loader as-is with `source: system`.

--- a/sqlite3/lib/src/wasm/vfs/indexed_db.dart
+++ b/sqlite3/lib/src/wasm/vfs/indexed_db.dart
@@ -607,7 +607,16 @@ final class IndexedDbFileSystem extends BaseVirtualFileSystem {
   /// Operations started after this [flush] call will not be awaited by the
   /// returned future.
   Future<void> flush() {
-    return _startWorkingIfNeeded(isImplicit: false);
+    if (!_isWorking) {
+      return _startWorkingIfNeeded(isImplicit: false);
+    }
+
+    // A batch is already being written, so `_startWorkingIfNeeded` would take
+    // no branch and complete immediately — before that batch, or anything
+    // queued behind it, reaches IndexedDB. Queue a no-op item instead: it lands
+    // at the tail of `_pendingWork` and completes only once the work ahead of
+    // it has been written, which is the guarantee documented above.
+    return _submitWorkFunction((_) async {}, 'flush');
   }
 
   @override


### PR DESCRIPTION
Fixes #408.

`11be8acb` made `flush()` return `_startWorkingIfNeeded(isImplicit: false)` directly. That is a genuine fence when the worker is idle — `_startWorkingIfNeeded` now awaits `_performWrites` — and it removed the marker's overhead. But while a batch is already being written, `_startWorkingIfNeeded` takes no branch and its future completes immediately, so `flush()` returns before that batch reaches IndexedDB. With `writeAutomatically: true`, `_isWorking` is set synchronously by the implicit start in `_submitWork`, so this is the ordinary state right after any write.

This keeps the idle fast path and restores the marker only when busy:

```dart
Future<void> flush() {
  if (!_isWorking) {
    return _startWorkingIfNeeded(isImplicit: false);
  }
  return _submitWorkFunction((_) async {}, 'flush');
}
```

Why the marker is sound: `_FunctionWorkItem` does not override `insertInto`, so it always lands at the tail of `_pendingWork` and is never merged or skipped. When the running batch finishes, `whenComplete` restarts work, and the next batch carries every write submitted before the flush plus the marker last. With `writeAutomatically: false` the running batch can only have been started explicitly, so its restart also uses `isImplicit: false` and proceeds. This is the same shape `close()` already uses.

### On testing

I haven't added a test, and want to be upfront about why rather than add one that passes for the wrong reason. The obvious check — flush, then read the data back through a fresh `IndexedDbFileSystem` or `AsynchronousIndexedDbFileSystem` — doesn't discriminate: an IndexedDB transaction that overlaps a pending readwrite transaction on the same store waits for it, so the read sees the data whether or not `flush()` actually awaited. A test that asserts on the number of event-loop turns before `flush()` resolves would catch it (it reads 0 on 3.5.2 and 7 on 3.3.3 in headless Chrome), but that is fragile. If you have a preferred way to observe work-queue state from a test, I'm happy to add one.

Verified: `dart analyze` clean on the changed file, `dart format` unchanged.
